### PR TITLE
Feature: managed aliases

### DIFF
--- a/Controller/AppController.php
+++ b/Controller/AppController.php
@@ -3,6 +3,7 @@ namespace EMS\CoreBundle\Controller;
 
 use Elasticsearch\Client;
 use EMS\CoreBundle\Entity\Job;
+use EMS\CoreBundle\Service\AliasService;
 use EMS\CoreBundle\Service\AssetService;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
@@ -126,7 +127,15 @@ class AppController extends Controller
 	protected function getHelperService()
 	{
 		return $this->container->get('ems.service.helper');
-	}	
+	}
+        
+        /**
+	 * @return AliasService
+	 */
+	protected function getAliasService()
+	{
+            return $this->container->get('ems.service.alias')->build();
+	}
 	
 	/**
 	 * 

--- a/Controller/ContentManagement/ManagedAliasController.php
+++ b/Controller/ContentManagement/ManagedAliasController.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace EMS\CoreBundle\Controller\ContentManagement;
+
+use Doctrine\ORM\EntityManager;
+use EMS\CoreBundle\Controller\AppController;
+use EMS\CoreBundle\Entity\ManagedAlias;
+use EMS\CoreBundle\Form\Form\ManagedAliasType;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @Route("/environment/managed-alias")
+ */
+class ManagedAliasController extends AppController
+{
+    /**
+     * @param Request $request
+     * 
+     * @Route("/add", name="environment_add_managed_alias")
+     */
+    public function addAction(Request $request)
+    {
+        $managedAlias = new ManagedAlias();
+        $form = $this->createForm(ManagedAliasType::class, $managedAlias);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->save($managedAlias, $this->getIndexActions($form));
+
+            $this->addFlash('notice', sprintf('Managed alias %s has been created', $managedAlias->getName()));
+            return $this->redirectToRoute('environment.index');
+        }
+
+        return $this->render('EMSCoreBundle:environment:managed_alias.html.twig', [
+            'new' => true,
+            'form' => $form->createView(),
+        ]);
+    }
+    
+    /**
+     * @param Request $request
+     * @param string  $id
+     *
+     * @Route("/edit/{id}", requirements={"id": "\d+"}, name="environment_edit_managed_alias")
+     */
+    public function editAction(Request $request, $id)
+    {
+        $managedAlias = $this->getAliasService()->getManagedAlias($id);
+        
+        if (!$managedAlias) {
+            throw new NotFoundHttpException('Unknow managed alias');
+        }
+        
+        $form = $this->createForm(ManagedAliasType::class, $managedAlias);
+        $form->handleRequest($request);
+        
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->save($managedAlias, $this->getIndexActions($form));
+            
+            $this->addFlash('notice', sprintf('Managed alias %s has been updated', $managedAlias->getName()));
+            
+            return $this->redirectToRoute('environment.index');
+        }
+        
+        return $this->render('EMSCoreBundle:environment:managed_alias.html.twig', [
+            'new' => false,
+            'form' => $form->createView(),
+        ]);
+    }
+    
+    /**
+     * @param string $id
+     *
+     * @Route("/remove/{id}", requirements={"id": "\d+"}, name="environment_remove_managed_alias")
+     * @Method({"POST"})
+     */
+    public function removeAction($id)
+    {
+        $managedAlias = $this->getAliasService()->getManagedAlias($id);
+        
+        if ($managedAlias) {
+            $this->getAliasService()->removeAlias($managedAlias->getAlias());
+            
+            /* @var $em EntityManager */
+            $em = $this->getDoctrine()->getManager();
+            $em->remove($managedAlias);
+            $em->flush();
+            
+            $this->addFlash('notice', sprintf('The managed %s has been removed', $managedAlias->getName()));
+        }
+        
+        return $this->redirectToRoute ( 'environment.index' );
+    }
+    
+    /**
+     * @param ManagedAlias $managedAlias
+     * @param array        $actions
+     */
+    private function save(ManagedAlias $managedAlias, array $actions)
+    {
+        $managedAlias->setAlias($this->getParameter('ems_core.instance_id'));
+        $this->getAliasService()->updateAlias($managedAlias->getAlias(), $actions);
+
+        /* @var $em EntityManager */
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($managedAlias);
+        $em->flush();
+    }
+    
+    /**
+     * @param Form $form
+     *
+     * @return array
+     */
+    private function getIndexActions(Form $form)
+    {
+        $actions = [];
+        $submitted = $form->get('indexes')->getData();
+        $indexes = array_keys($form->getConfig()->getOption('indexes'));
+        
+        if (empty($submitted)) {
+            return $actions;
+        }
+        
+        foreach ($indexes as $index) {
+            if (in_array($index, $submitted)) {
+                $actions['add'][] = $index;
+            } else {
+                $actions['remove'][] = $index;
+            }
+        }
+        
+        return $actions;
+    }
+}

--- a/Entity/ManagedAlias.php
+++ b/Entity/ManagedAlias.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace EMS\CoreBundle\Entity;
+
+use EMS\CoreBundle\Validator\Constraints as EMSAssert;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\PrePersist;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+/**
+ * Managed Alias
+ *
+ * @ORM\Table(name="managed_alias")
+ * @ORM\Entity(repositoryClass="EMS\CoreBundle\Repository\ManagedAliasRepository")
+ * @ORM\HasLifecycleCallbacks()
+ * 
+ * @UniqueEntity(fields={"name"}, message="Name already exists!")
+ */
+class ManagedAlias
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+    
+    /**
+     * @var string
+     * 
+     * @EMSAssert\AliasName()
+     * 
+     * @ORM\Column(name="name", type="string", length=255, unique=true)
+     */
+    private $name;
+    
+    /**
+     * @var string
+     * @ORM\Column(name="alias", type="string", length=255, unique=true)
+     */
+    private $alias;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created", type="datetime")
+     */
+    private $created;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="modified", type="datetime")
+     */
+    private $modified;
+    
+    /**
+     * @var array
+     */
+    private $indexes = [];
+    
+    /**
+     * @var int
+     */
+    private $total;
+  
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="color", type="string", length=50, nullable=true)
+     */
+    private $color;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="extra", type="text", nullable=true)
+     */
+    private $extra;
+    
+    /**
+     * Managed Alias
+     */
+    public function __construct()
+    {
+        $this->created = new \DateTime();
+    }
+    
+    /**
+     * @return string
+     */
+    public function __toString() {
+    	return $this->name;
+    }
+  
+    /**
+     * @ORM\PrePersist
+     * @ORM\PreUpdate
+     */
+    public function updateModified()
+    {
+    	$this->modified = new \DateTime();
+    }
+    
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getModified()
+    {
+        return $this->modified;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+    	return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return ManagedAlias
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+    
+    /**
+     * @param string $instanceId
+     */
+    public function setAlias($instanceId)
+    {
+        $this->alias = $instanceId . $this->getName();
+    }
+
+    /**
+     * @return array
+     */
+    public function getIndexes()
+    {
+        return $this->indexes;
+    }
+    
+    /**
+     * @param array $indexes
+     *
+     * @return ManagedAlias
+     */
+    public function setIndexes(array $indexes)
+    {
+        $this->indexes = $indexes;
+
+        return $this;
+    }
+    
+    /**
+     * @return int
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     * @param int $total
+     * 
+     * @return ManagedAlias
+     */
+    public function setTotal($total)
+    {
+        $this->total = $total;
+        
+        return $this;
+    }
+        
+    /**
+     * @return string
+     */
+    public function getColor()
+    {
+        return $this->color;
+    }
+ 
+    /**
+     * @param string $color
+     *
+     * @return ManagedAlias
+     */
+    public function setColor($color)
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExtra()
+    {
+        return $this->extra;
+    }
+
+    /**
+     * @param string $extra
+     *
+     * @return ManagedAlias
+     */
+    public function setExtra($extra)
+    {
+        $this->extra = $extra;
+
+        return $this;
+    }
+}

--- a/Form/Field/AlignIndexesType.php
+++ b/Form/Field/AlignIndexesType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace EMS\CoreBundle\Form\Field;
+
+use EMS\CoreBundle\Entity\ManagedAlias;
+use EMS\CoreBundle\Service\AliasService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AlignIndexesType extends SelectPickerType
+{
+    /**
+     * @var AliasService
+     */
+    private $aliasService;
+    
+    /**
+     * @param AliasService $aliasService
+     */
+    public function __construct(AliasService $aliasService)
+    {
+        parent::__construct();
+        
+        $this->aliasService = $aliasService;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $managedAliases = $this->aliasService->getManagedAliases();
+        $choices = [];
+        
+        foreach ($managedAliases as $managedAlias) {
+            /* @var $managedAlias ManagedAlias */
+            $choices[$managedAlias->getName()] = $managedAlias;
+        }
+        
+        $resolver->setDefaults([
+            'mapped' => false,
+            'required' => false,
+            'multiple' => false,
+            'label' => 'Align with:',
+            'placeholder' => 'select managed alias',
+            'choices' => array_keys($choices),
+            'choice_attr' => function ($name) use ($choices) {
+                $managedAlias = $choices[$name];
+            
+                return [
+                    'data-indexes' => '["'.implode('", "',array_keys($managedAlias->getIndexes())) . '"]',
+                    'data-content' => '<span class="text-'.$managedAlias->getColor().'"><i class="fa fa-code-fork"></i>&nbsp;&nbsp;'. $managedAlias->getName().'</span>'
+                ];
+            }
+        ]);
+    }
+}

--- a/Form/Form/ManagedAliasType.php
+++ b/Form/Form/ManagedAliasType.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace EMS\CoreBundle\Form\Form;
+
+use EMS\CoreBundle\Entity\ManagedAlias;
+use EMS\CoreBundle\Form\Field\AlignIndexesType;
+use EMS\CoreBundle\Form\Field\ColorPickerType;
+use EMS\CoreBundle\Form\Field\IconTextType;
+use EMS\CoreBundle\Form\Field\SubmitEmsType;
+use EMS\CoreBundle\Service\AliasService;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Count;
+
+class ManagedAliasType extends AbstractType
+{
+    /**
+     * @var AliasService
+     */
+    private $aliasService;
+    
+    /**
+     * @param AliasService $aliasService
+     */
+    public function __construct(AliasService $aliasService)
+    {
+        $this->aliasService = $aliasService;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        /* @var $data ManagedAlias */
+        $data = $builder->getData();
+        
+        $builder
+            ->add('name', IconTextType::class, ['icon' => 'fa fa-tag'])
+            ->add('color', ColorPickerType::class, ['required' => false])
+            ->add('extra', TextareaType::class, [
+                'required' => false,
+                'attr' => ['rows' => '6'],
+            ])
+            ->add('indexes', ChoiceType::class, [
+                'data' => array_keys($data->getIndexes()),
+                'choices' => array_keys($options['indexes']),
+                'choice_label' => function ($val) {
+                    return $val;
+                }, 
+                'choice_attr' => function($val, $key, $index) use ($options) {
+                    return [
+                        'class' => 'align-index',
+                        'data-count' => $options['indexes'][$val]['count'],
+                    ];
+                },
+                'mapped' => false,
+                'expanded' => true,
+                'multiple' => true,
+            ])
+            ->add('align_indexes', AlignIndexesType::class)
+            ->add('save', SubmitEmsType::class, [
+                'attr' => ['class' => 'btn-primary btn-sm '],
+                'icon' => 'fa fa-save'
+            ]);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => ManagedAlias::class,
+            'indexes' => $this->aliasService->build()->getAllIndexes(),
+        ]);
+    }
+}

--- a/Repository/EnvironmentRepository.php
+++ b/Repository/EnvironmentRepository.php
@@ -22,6 +22,17 @@ class EnvironmentRepository extends \Doctrine\ORM\EntityRepository
     	}
     	return parent::findBy($criteria, $orderBy, $limit, $offset);
     }
+    
+    /**
+     * @return array
+     */
+    public function findAllAliases()
+    {
+        $qb = $this->createQueryBuilder('e', 'e.alias');
+        $qb->select('e.alias, e.name, e.managed');
+        
+        return $qb->getQuery()->getResult();
+    }
 	
     public function getEnvironmentsStats() {
         /** @var QueryBuilder $qb */

--- a/Repository/ManagedAliasRepository.php
+++ b/Repository/ManagedAliasRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EMS\CoreBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Managed Alias Repository
+ */
+class ManagedAliasRepository extends EntityRepository
+{
+    /**
+     * @return array
+     */
+    public function findAllAliases()
+    {
+        $conn = $this->getEntityManager()->getConnection();
+        $qb = $conn->createQueryBuilder();
+        $qb->addSelect('alias')->from('managed_alias');
+        
+        return $qb->execute()->fetchAll(\PDO::FETCH_COLUMN);
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -344,6 +344,16 @@ services:
         arguments: ['@doctrine']
         tags:
             - { name: form.type }
+    ems.form.field.alignindexes:
+        class: EMS\CoreBundle\Form\Field\AlignIndexesType
+        arguments: ['@ems.service.alias']
+        tags:
+            - { name: form.type }
+    ems.form.managed_alias:
+        class: EMS\CoreBundle\Form\Form\ManagedAliasType
+        arguments: ['@ems.service.alias']
+        tags:
+            - { name: form.type }
             
             
 ### regular services
@@ -355,6 +365,9 @@ services:
         arguments: ['@doctrine', '@security.authorization_checker', '@security.token_storage', '%ems_core.lock_time%', '@app.elasticsearch', '@ems.service.mapping', '%ems_core.instance_id%', '@session', '@form.factory', '@service_container', '@form.registry', '@event_dispatcher', '%ems_private_key%']
         tags:
             - { name: kernel.event_listener, event: ems_core.revision.update_referers, method: updateReferers, priority: 0 }
+    ems.service.alias:
+        class: EMS\CoreBundle\Service\AliasService
+        arguments: ['@app.elasticsearch', '@doctrine']
     ems.service.environment:
         class: EMS\CoreBundle\Service\EnvironmentService
         arguments: ['@doctrine', '@session', '@ems.service.user', '@security.authorization_checker']

--- a/Resources/views/elements/post-button.html.twig
+++ b/Resources/views/elements/post-button.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'EMSCoreBundle' %}{% if message is defined %}
 <div class="btn-group">
-  <button type="button" class="btn {% if class is defined %}{% else %}btn-sm{% endif %} btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button type="button" class="btn {% if class is defined %}{{ class }}{% else %}btn-sm btn-danger{% endif %} dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     	{% if icon is defined %}
 			{% if icon|slice(0,10) == 'glyphicon-'  %}
 				<span class="glyphicon {{ icon }}"></span>&nbsp;

--- a/Resources/views/environment/index.html.twig
+++ b/Resources/views/environment/index.html.twig
@@ -75,7 +75,7 @@
 							<th>Action</th>
 						</tr>
 						{% for environment in environments %}
-							{{ 'Environmen\'s info'|debug({name: environment.name}) }}
+							{{ "Environmen's info"|debug({name: environment.name}) }}
 							{% if environment.managed  %}
 								<tr>
 									<td class="text-center">{{ loop.index }}.</td>
@@ -145,7 +145,6 @@
 			<div class="box-header with-border">
 				<i class="fa fa-database"></i>
 				<h3 class="box-title">Externals environments</h3>{{ 'List referenced external evironment'|debug }}
-				<a class="btn btn-xs btn-primary pull-right" href="{{ path('environment.add') }}"><i class="fa fa-plus"></i> Add environment</a>
 			</div>
 			<!-- /.box-header -->
 			<div class="box-body">
@@ -208,6 +207,60 @@
 			</div>
 			<!-- /.box-body -->
 		</div>
+                        
+                <div class="box ">
+                    <div class="box-header with-border">
+                        <i class="fa fa-code-fork"></i>
+                        <h3 class="box-title">{{ 'Managed Aliases'|trans }}</h3>
+                        <div class="btn-group  pull-right">
+                            <a class="btn btn-xs btn-primary" href="{{ path('environment_add_managed_alias') }}"><i class="fa fa-plus"></i> Add managed alias</a>
+                        </div>
+                    </div>
+                    {% if managedAliases|length > 0 %}
+                        <div class="box-body">
+                            <div class="table-responsive">
+                                <table class="table table-condensed table-striped">
+                                    <tbody>
+                                        <tr>
+                                            <th class="text-center" style="width: 10px">#</th>
+                                            <th>Name</th>
+                                            <th>Alias</th>
+                                            <th>Indexes</th>
+                                            <th>Total</th>
+                                            <th>Action</th>
+                                        </tr>
+                                        {% for managedAlias in managedAliases %}
+                                            <tr>
+                                                <td class="text-center">{{ loop.index }}.</td>
+                                                <td>
+                                                    <span class="badge bg-{{ managedAlias.color|raw }}">{{ managedAlias.name|humanize }}</span>		
+                                                </td>
+                                                <td>{{ managedAlias.alias }}</td>
+                                                <td>{{ managedAlias.indexes|length }}</td>
+                                                <td>{{ managedAlias.total }}</td>
+                                                <td>
+                                                    <div class="btn-group">
+                                                        {% include 'EMSCoreBundle:elements:get-button.html.twig' with {
+                                                            'url': path('environment_edit_managed_alias', {'id': managedAlias.id}),
+                                                            'label': 'Edit',
+                                                            'icon': 'pencil'
+                                                        }%}
+                                                        {% include 'EMSCoreBundle:elements:post-button.html.twig' with {
+                                                            'url': path('environment_remove_managed_alias', {'id': managedAlias.id}),
+                                                            'message': 'Delete the managed alias ' ~ managedAlias.name|humanize ~ ' ?',
+                                                            'label': 'Delete',
+                                                            'icon': 'trash'
+                                                        } %}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
 	</div>
 	
 </div>
@@ -222,7 +275,7 @@
 			</div>
 			<!-- /.box-header -->
 			<div class="box-body">
-				{% if unmanagedIndexes|length == 0 %}
+				{% if unreferencedAliases|length == 0 %}
 					All indexes are referenced
 				{% else %}
 			
@@ -232,21 +285,34 @@
 							<tr>
 								<th class="text-center" style="width: 10px">#</th>
 								<th>Name</th>
+								<th class="text-center">Indexes</th>
 								<th class="text-center">Total</th>
 								<th>Action</th>
 							</tr>
-							{% for alias in unmanagedIndexes %}
+							{% for name, alias in unreferencedAliases %}
 								<tr>
 									<td class="text-center">{{ loop.index }}.</td>
-									<td>{{ alias.name }}</td>
+									<td>{{ name }}</td>
+									<td class="text-center">{{ alias.indexes|length }}</td>
 									<td class="text-center">{{ alias.total|number_format }}</td>
 									<td>
-										{% include 'EMSCoreBundle:elements:post-button.html.twig' with {
-											'url': path('environment.attach', {'name': alias.name }),
-											'message': 'Attach the alias ' ~ alias.name|humanize ~ ' ?',
-											'label': 'Attach',
-											'icon': 'plus'
-										}%}
+                                                                            <div class="btn-group">
+                                                                                {% if alias.indexes|length == 1 %}
+                                                                                    {% include 'EMSCoreBundle:elements:post-button.html.twig' with {
+                                                                                            'url': path('environment.attach', {'name': name }),
+                                                                                            'message': 'Attach the alias ' ~ name|humanize ~ ' ?',
+                                                                                            'label': 'Attach',
+                                                                                            'icon': 'plus',
+                                                                                            'class': 'btn-sm btn-primary',
+                                                                                    }%}
+                                                                                {% endif %}
+                                                                                {% include 'EMSCoreBundle:elements:post-button.html.twig' with {
+                                                                                        'url': path('environment.remove.alias', {'name': name }),
+                                                                                        'message': 'Delete the alias ' ~ name|humanize ~ ' ?',
+                                                                                        'label': 'Delete',
+                                                                                        'icon': 'trash',
+                                                                                }%}
+                                                                            </div>
 									</td>
 								</tr>
 							{% endfor %}
@@ -287,7 +353,7 @@
 							<tr>
 								<td class="text-center">{{ loop.index }}.</td>
 								<td>{{ index.name }}</td>
-								<td class="text-center">{{ index.total|number_format }}</td>
+								<td class="text-center">{{ index.count|number_format }}</td>
 								<td>
 								
 									<div class="btn-group">

--- a/Resources/views/environment/managed_alias.html.twig
+++ b/Resources/views/environment/managed_alias.html.twig
@@ -1,0 +1,85 @@
+{% extends 'EMSCoreBundle::base.html.twig' %}{% trans_default_domain 'EMSCoreBundle' %}
+
+{% if new %}
+    {% set title = 'Add managed alias'|trans %}
+{% else %}
+    {% set title = 'Edit managed alias'|trans %}
+{% endif %}
+
+{% block title %}{{ title }}{% endblock %}
+{% block pagetitle %}{{ title }}{% endblock %} 
+
+{% block body %}
+    <div class="row">
+        {{ form_start(form) }}
+        <div class="col-md-6">
+            <div class="box box-primary">
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ title }}</h3>
+                </div>
+                <div class="box-body">
+                    {{ form_row(form.name) }}
+                    {{ form_row(form.color) }}
+                    {{ form_row(form.extra) }}
+                </div>
+                <div class="box-footer">
+                    <div class="pull-right">
+                        {{ form_widget(form.save) }}
+                    </div>
+                </div>
+            </div>
+        </div>
+            <div class="col-md-6">
+            <div class="box box-primary">
+                <div class="box-header with-border">
+                    <h3 class="box-title">Indexes</h3>
+                </div>
+                <div class="box-body">
+                    {{ form_row(form.align_indexes) }}
+                    
+                    <table class="table table-condensed table-striped">
+                        <tbody>
+                            <tr>
+                                <th>Index</th>
+                                <th>Total</th>
+                            </tr>
+                            {% for checkbox in form.indexes %}
+                                <tr>
+                                    <td>{{ form_widget(checkbox) }}</td>
+                                    <td>{{ attribute(checkbox.vars.attr, 'data-count') }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="box-footer">
+                    <div class="pull-right">
+                    </div>
+                </div>
+            </div>
+        </div>
+        {{ form_end(form) }}
+    </div>
+{% endblock %} 
+
+
+{% block javascripts %}
+    {% include 'EMSCoreBundle:app:menu.html.twig' with {
+        'item':  'environment-managed-alias'
+    }%}
+    <script type="text/javascript">
+        $(function() {
+            $('#managed_alias_align_indexes').on('change', function() {
+                var data = $(this).find("option:selected").data();
+
+                $('.align-index').prop( "checked", false);
+
+                if (data.indexes !== undefined) {
+                    data.indexes.map(function (index) {
+                        $('input[type="checkbox"][value="'+ index +'"]').prop("checked", true);
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}	

--- a/Service/AliasService.php
+++ b/Service/AliasService.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace EMS\CoreBundle\Service;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Elasticsearch\Client;
+use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Entity\ManagedAlias;
+use EMS\CoreBundle\Repository\EnvironmentRepository;
+use EMS\CoreBundle\Repository\ManagedAliasRepository;
+
+class AliasService
+{
+    /**
+     * @var Client
+     */
+    private $client;
+    
+    /**
+     * @var EnvironmentRepository
+     */
+    private $envRepo;
+    
+    /**
+     * @var ManagedAliasRepository
+     */
+    private $managedAliasRepo;
+    
+    /**
+     * [name => [indexes, total, environment, managed]]
+     * 
+     * @var array
+     */
+    private $aliases = [];
+
+    /**
+     * [name => [[name => count]]
+     * 
+     * @var array
+     */
+    private $orphanIndexes = [];
+    
+    /**
+     * @var bool 
+     */
+    private $isBuild = false;
+
+    /**
+     * @param Client   $client
+     * @param Registry $registry
+     */
+    public function __construct(Client $client, Registry $doctrine)
+    {
+        $this->client = $client;
+        $this->envRepo = $doctrine->getRepository(Environment::class);
+        $this->managedAliasRepo = $doctrine->getRepository(ManagedAlias::class);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasAlias($name)
+    {
+        return isset($this->aliases[$name]);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return array
+     */
+    public function getAlias($name)
+    {
+        return $this->aliases[$name];
+    }
+    
+    /**
+     * Get all aliases
+     * 
+     * @return array
+     */
+    public function getAliases()
+    {
+        return $this->aliases;
+    }
+    
+    /**
+     * @param int $id
+     *
+     * @return ManagedAlias
+     */
+    public function getManagedAlias($id)
+    {
+        $managedAlias = $this->managedAliasRepo->find($id);
+        
+        if ($this->hasAlias($managedAlias->getAlias())) {
+            $alias = $this->getAlias($managedAlias->getAlias());
+            $managedAlias->setIndexes($alias['indexes']);
+        }
+        
+        return $managedAlias;
+    }
+    
+    /**
+     * @return ManagedAliases[]
+     */
+    public function getManagedAliases()
+    {
+        $managedAliases = $this->managedAliasRepo->findAll();
+        
+        foreach ($managedAliases as $managedAlias) {
+            /* @var $managedAlias ManagedAlias */
+            if (!$this->hasAlias($managedAlias->getAlias())) {
+                continue;
+            }
+            
+            $alias = $this->getAlias($managedAlias->getAlias());
+            $managedAlias->setIndexes($alias['indexes']);
+            $managedAlias->setTotal($alias['total']);
+        }
+        
+        return $managedAliases;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getAllIndexes()
+    {
+        $indexes = [];
+        $indices = $this->client->cat()->indices();
+        
+        foreach ($indices as $data) {
+            $name = $data['index'];
+            
+            if (!$this->validIndexName($name)) {
+                continue;
+            }
+            
+            $indexes[$name] = ['name' => $name, 'count' => $data['docs.count']];
+        }
+        
+        ksort($indexes);
+        
+        return $indexes;
+    }
+    
+    /**
+     * Aliases without an environment
+     * 
+     * @return array
+     */
+    public function getUnreferencedAliases()
+    {
+        $aliases = $this->getAliases();
+        
+        return array_filter($aliases, function (array $alias) {
+            return $alias['environment'] === null && $alias['managed'] === false;
+        });
+    }
+
+    /**
+     * Indexes without aliases
+     * 
+     * @return array
+     */
+    public function getOrphanIndexes()
+    {
+        return $this->orphanIndexes;
+    }
+
+    /**
+     * Build orphan indexes, unreferenced aliases
+     * 
+     * @return self
+     */
+    public function build()
+    {
+        if ($this->isBuild) {
+            return $this;
+        }
+        
+        $data = $this->getData();
+        $environmentAliases = $this->envRepo->findAllAliases();
+        $managedAliases = $this->managedAliasRepo->findAllAliases();
+        
+        foreach ($data as $index => $info) {
+            $aliases = array_keys($info['aliases']);
+            
+            if (0 === count($aliases)) {
+                $this->addOrphanIndex($index);
+                continue;
+            }
+            
+            foreach ($aliases as $alias) {
+                if (array_key_exists($alias, $environmentAliases)) {
+                    $this->addAlias($alias, $index, $environmentAliases[$alias]);
+                } else if (in_array($alias, $managedAliases)) {
+                    $this->addAlias($alias, $index, [], true);
+                } else {
+                    $this->addAlias($alias, $index);
+                }
+                
+                
+            }
+        }
+        
+        $this->isBuild = true;
+        
+        return $this;
+    }
+    
+    /**
+     * @param string $alias
+     * @param array  $actions
+     * 
+     * @return void
+     */
+    public function updateAlias($alias, array $actions)
+    {
+        if (empty($actions)) {
+            return;
+        }
+        
+        $json = [];
+        
+        foreach ($actions as $type => $indexes) {
+            foreach ($indexes as $index) {
+                $json[] = [$type => ['index' => $index, 'alias' => $alias]];
+            }
+        }
+        
+        $this->client->indices()->updateAliases([
+            'body' => ['actions' => $json]
+        ]);
+    }
+    
+    /**
+     * @param string $alias
+     */
+    public function removeAlias($name)
+    {
+        if (!$this->hasAlias($name)) {
+            return false;
+        }
+        
+        $actions = [];
+        $alias = $this->getAlias($name);
+        
+        foreach ($alias['indexes'] as $index) {
+            $actions[] = ['remove' => ['index' => $index['name'], 'alias' => $name]];
+        }
+        
+        $this->client->indices()->updateAliases([
+            'body' => ['actions' => $actions]
+        ]);
+        
+        return true;
+    }
+        
+    /**
+     * @param string $name
+     * @param string $index
+     * @param array  $env
+     * @param bool   $managed
+     *
+     * @return void
+     */
+    private function addAlias($name, $index, array $env = [], $managed = false)
+    {
+        if ($this->hasAlias($name)) {
+            $this->aliases[$name]['indexes'][$index] = $this->getIndex($index);
+            return;
+        }
+        
+        $this->aliases[$name] = [
+            'indexes' => [$index => $this->getIndex($index)],
+            'total' => $this->count($name),
+            'environment' => isset($env['name']) ? $env['name'] : null,
+            'managed' => isset($env['managed']) ? $env['managed'] : $managed,
+        ]; 
+    }
+    
+    /**
+     * @param string $name
+     */
+    private function addOrphanIndex($name)
+    {
+        $this->orphanIndexes[] = $this->getIndex($name);
+    }
+    
+    private function getIndex($name)
+    {
+        return ['name' => $name, 'count' => $this->count($name)];
+    }
+    
+    /**
+     * @param string $name
+     *
+     * @return int
+     */
+    private function count($name) 
+    {
+        $result = $this->client->count(['index' => $name]);
+        
+        return isset($result['count']) ? (int) $result['count'] : 0;
+    }
+
+    /**
+     * Filters out indexes that start with .*
+     * 
+     * @return array
+     */
+    private function getData()
+    {
+        $indexesAliases = $this->client->indices()->getAliases();
+
+        return array_filter(
+            $indexesAliases, 
+            [$this, 'validIndexName'], 
+            \ARRAY_FILTER_USE_KEY
+        );
+    }
+    
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    private function validIndexName($name)
+    {
+        return strcmp($name{0}, '.') != 0;
+    }
+}

--- a/Validator/Constraints/AliasName.php
+++ b/Validator/Constraints/AliasName.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EMS\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class AliasName extends Constraint
+{
+    public $invalid = 'Must respects the following regex {{ regex }}';
+}

--- a/Validator/Constraints/AliasNameValidator.php
+++ b/Validator/Constraints/AliasNameValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EMS\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class AliasNameValidator extends ConstraintValidator
+{
+    /**
+     * @param string    $value
+     * @param AliasName $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $regex = '/^[a-z][a-z0-9\-_]*$/';
+        
+        if (!preg_match($regex, $value) || strlen($value) > 100) {
+             $this->context
+                ->buildViolation($constraint->invalid)
+                ->setParameter('{{ regex }}', $regex)
+                ->atPath('name')
+                ->addViolation()
+            ;
+             
+            return;
+        } 
+    }
+}


### PR DESCRIPTION
Environment local and external should only use **1** index, but we want to manage aliases with multiple indexes (indices).

On the environment page we can now view/create/edit and delete managed aliases. Managed aliases are stored in 'managed_alias' table. It's also possible to align managed aliases on their edit page.

Added indexes counter to the unreferenced aliases overview. Disabled the attach function for unreferenced aliases with multiple indexes. And also added the delete function for unreferenced aliases.