### PR TITLE
Fix title attribute for object pickers

### DIFF
--- a/Form/Field/ObjectChoiceListItem.php
+++ b/Form/Field/ObjectChoiceListItem.php
@@ -6,6 +6,7 @@ use EMS\CoreBundle\Entity\ContentType;
 class ObjectChoiceListItem {
 
 	private $label;
+	private $title;
 	private $value;
 	private $group;
 	private $color;
@@ -26,9 +27,11 @@ class ObjectChoiceListItem {
 			$this->label = '<i class="'.(null !== $contentType->getIcon()?$contentType->getIcon():'fa fa-question').'" data-ouuid="'.$this->value.'"></i>&nbsp;&nbsp;';
 			if(null !== $contentType->getLabelField() && isset($object['_source'][$contentType->getLabelField()])){
 				$this->label .= $object['_source'][$contentType->getLabelField()];
+				$this->title = $object['_source'][$contentType->getLabelField()];
 			}
 			else {
-				$this->label .= $this->value;				
+				$this->label .= $this->value;
+				$this->title = $this->value;
 			}
 			
 
@@ -47,7 +50,12 @@ class ObjectChoiceListItem {
 	
 	public function getLabel(){
 		return $this->label;
-	}	
+	}
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
 	
 	public function getGroup(){
 		return $this->group;

--- a/Form/Field/ObjectPickerType.php
+++ b/Form/Field/ObjectPickerType.php
@@ -41,6 +41,13 @@ class ObjectPickerType extends Select2Type {
 		    'choice_label' => function ($value, $key, $index) {
 		    	return $value->getLabel();
 		    },
+            'choice_attr' => function($val, $key, $index) {
+			    if ($val instanceof ObjectChoiceListItem) {
+                    return ['title' => $val->getTitle()];
+                }
+
+                return [];
+            },
 		    'group_by' => function($value, $key, $index) {
 		    	return $value->getGroup();
 		    },


### PR DESCRIPTION
Set the correct title attribute on the select options.
Now select2 will use the html value as title on load.