### PR TITLE
bugfix: computed sha1 mismatch

### DIFF
--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -456,6 +456,10 @@ class DataService
 					])['_source'];
 					
 					DataService::ksortRecursive($indexedItem);
+
+					if (isset($indexedItem[Mapping::PUBLISHED_DATETIME_FIELD])) {
+					    unset($indexedItem[Mapping::PUBLISHED_DATETIME_FIELD]);
+                    }
 					
 					if(isset($indexedItem[Mapping::HASH_FIELD])){
 						if($indexedItem[Mapping::HASH_FIELD] != $revision->getSha1()) {


### PR DESCRIPTION
The dataservice should not check the published datetime field (_published_datetime).
When publishing this is also added after the signing.