### PR TITLE
fix: update composer requirement for commonBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"symfony/web-link": "^4.1",
 		"symfony/webpack-encore-pack": "*",
 		"symfony/yaml": "^4.1",
-		"elasticms/common-bundle": "^1.0",
+		"elasticms/common-bundle": "^1.6.3",
 		"maennchen/zipstream-php" : "^0.5",
 		"doctrine/doctrine-migrations-bundle" : "^1.3",
 		"sensiolabs/ansi-to-html" : "^1.1",


### PR DESCRIPTION
We should at least require commonBundle 1.6.3