### PR TITLE
Import helpers bulker, indexer, mappings

### DIFF
--- a/Command/MigrateCommand.php
+++ b/Command/MigrateCommand.php
@@ -1,6 +1,5 @@
 <?php
 
-// src/EMS/CoreBundle/Command/GreetCommand.php
 namespace EMS\CoreBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
@@ -13,7 +12,7 @@ use EMS\CoreBundle\Form\Form\RevisionType;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\Mapping;
-use EMS\CommonBundle\Elasticsearch\Bulk\Bulker;
+use EMS\CoreBundle\Elasticsearch\Bulker;
 use Monolog\Logger;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;

--- a/Elasticsearch/Bulker.php
+++ b/Elasticsearch/Bulker.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace EMS\CoreBundle\Elasticsearch;
+
+use Elasticsearch\Client;
+use EMS\CommonBundle\Elasticsearch\DocumentInterface;
+use Psr\Log\LoggerInterface;
+
+class Bulker
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var array
+     */
+    private $params = ['body' => []];
+
+    /**
+     * @var int
+     */
+    private $counter = 0;
+
+    /**
+     * @var int
+     */
+    private $size = 500;
+
+    /**
+     * @var bool
+     */
+    private $singleIndex = false;
+
+    /**
+     * @var bool
+     */
+    private $enableSha1 = true;
+
+    /**
+     * @param Client          $client
+     * @param LoggerInterface $logger
+     */
+    public function __construct(Client $client, LoggerInterface $logger)
+    {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     *
+     * @return Bulker
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * @param int $size
+     *
+     * @return Bulker
+     */
+    public function setSize(int $size): Bulker
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $singleIndex
+     *
+     * @return Bulker
+     */
+    public function setSingleIndex(bool $singleIndex): Bulker
+    {
+        $this->singleIndex = $singleIndex;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $enableSha1
+     *
+     * @return Bulker
+     */
+    public function setEnableSha1(bool $enableSha1): Bulker
+    {
+        $this->enableSha1 = $enableSha1;
+
+        return $this;
+    }
+
+    /**
+     * @param array $config
+     * @param array $body
+     *
+     * @return bool
+     */
+    public function index(array $config, array $body): bool
+    {
+        if ($this->enableSha1) {
+            $body['_sha1'] = sha1(json_encode($body));
+        }
+
+        $this->params['body'][] = ['index' => $config];
+        $this->params['body'][] = $body;
+
+        $this->counter++;
+
+        return $this->send();
+    }
+
+    /**
+     * @param DocumentInterface $document
+     * @param string            $index
+     *
+     * @return bool
+     */
+    public function indexDocument(DocumentInterface $document, string $index): bool
+    {
+        $config = [
+            '_index' => $index,
+            '_type'  => ($this->singleIndex ? 'doc' : $document->getType()),
+            '_id'    => $document->getId(),
+        ];
+        $body = $document->getSource();
+
+        if ($this->singleIndex) {
+            $body = array_merge(['_contenttype' => $document->getType()], $body);
+        }
+
+        return $this->index($config, $body);
+    }
+
+    /**
+     * @param bool $force
+     *
+     * @return bool
+     */
+    public function send($force = false): bool
+    {
+        if (0 === $this->counter) {
+            return false;
+        }
+
+        if (!$force && $this->counter < $this->size) {
+            return false;
+        }
+
+        try {
+            $response = $this->client->bulk($this->params);
+            $this->logResponse($response);
+
+            $this->params = ['body' => []];
+            $this->counter = 0;
+        } catch (\Exception $e) {
+            $this->logger->critical($e->getMessage());
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $response
+     */
+    private function logResponse(array $response)
+    {
+        foreach($response['items'] as $item) {
+            $action = array_shift($item);
+
+            if (!isset($action['error'])) {
+                continue; //no error
+            }
+
+            $this->logger->critical('{type} {id} : {error} {reason}', [
+                'type'   => $action['_type'],
+                'id'     => $action['_id'],
+                'error'  => $action['error']['type'],
+                'reason' => $action['error']['reason'],
+            ]);
+        }
+
+        $this->logger->debug('bulked {count} items in {took}ms', [
+            'count' => count($response['items']),
+            'took'  => $response['took'],
+        ]);
+    }
+}

--- a/Elasticsearch/Index/Mappings.php
+++ b/Elasticsearch/Index/Mappings.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EMS\CoreBundle\Elasticsearch\Index;
+
+use EMS\CoreBundle\Service\Mapping as EMS;
+
+class Mappings
+{
+    private $mappings = [];
+    private $defaultProperties = [];
+
+    public function __construct(array $languageAnalyzers = [])
+    {
+        foreach ($languageAnalyzers as $language => $analyzer) {
+            $this->defaultProperties['all_'.$language] = [
+                'type' => 'text',
+                'store' => true,
+                'analyzer' => $analyzer,
+            ];
+        }
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->mappings);
+    }
+
+    public function toArray(): array
+    {
+        return $this->mappings;
+    }
+
+    public function add(string $name, array $mapping, ?string $type = 'doc'): Mappings
+    {
+        if (!isset($this->mappings[$type])) {
+            $this->mappings[$type] = $this->getDefaults();
+        }
+
+        $this->mappings[$type]['properties'][$name] = $mapping;
+
+        return $this;
+    }
+
+    private function getDefaults()
+    {
+        return [
+            '_all' => ['store' => true, 'enabled' => true],
+            'properties' => array_merge([
+                EMS::CONTENT_TYPE_FIELD => ['type' => 'keyword'],
+                EMS::HASH_FIELD => ['type' => 'keyword'],
+            ], $this->defaultProperties)
+        ];
+    }
+}

--- a/Elasticsearch/Index/Settings.php
+++ b/Elasticsearch/Index/Settings.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace EMS\CoreBundle\Elasticsearch\Index;
+
+class Settings
+{
+    private $filters = [];
+    private $analyzers = [];
+    private $languageAnalyzers = [];
+
+    public function isEmpty(): bool
+    {
+        return empty($this->filters) && empty($this->analyzers);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'analysis' => [
+                'filter' => $this->filters,
+                'analyzer' => $this->analyzers,
+            ]
+        ];
+    }
+
+    public function getLanguageAnalyzers(): array
+    {
+        return $this->languageAnalyzers;
+    }
+
+    public function addAnalyzerHtmlStrip(): Settings
+    {
+        $this->analyzers['html_strip'] = $this->createCustomAnalyzer('standard');
+
+        return $this;
+    }
+
+    public function addAnalyzersEnglish(): Settings
+    {
+        $this->filters['english_stop'] = $this->getFilterStop('_english_');
+        $this->filters['english_stemmer'] = $this->getFilterStemmer('english');
+        $this->filters['empty_elision'] = $this->getFilterElision();
+
+        $this->analyzers['english_for_highlighting'] = $this->createCustomAnalyzer(
+            ['standard', 'lowercase', 'empty_elision', 'english_stemmer', 'english_stop']
+        );
+
+        $this->languageAnalyzers['en'] = 'english_for_highlighting';
+
+        return $this;
+    }
+
+    public function addAnalyzersFrench(): Settings
+    {
+        $this->filters['french_stop'] = $this->getFilterStop('_french_');
+        $this->filters['french_stemmer'] = $this->getFilterStemmer('light_french');
+        $this->filters['french_elision'] = $this->getFilterElision(['l', 'm', 't', 'qu', 'n', 's', 'j', 'd', 'c', 'jusqu', 'quoiqu', 'lorsqu', 'puisq']);
+
+        $this->analyzers['french_for_highlighting'] = $this->createCustomAnalyzer(
+            ['standard', 'asciifolding', 'lowercase', 'french_elision', 'french_stemmer', 'french_stop']
+        );
+
+        $this->languageAnalyzers['fr'] = 'french_for_highlighting';
+
+        return $this;
+    }
+
+    public function addAnalyzersDutch(): Settings
+    {
+        $this->filters['dutch_stop'] = $this->getFilterStop('_dutch_');
+        $this->filters['dutch_stemmer'] = $this->getFilterStemmer('dutch');
+        $this->filters['empty_elision'] = $this->getFilterElision();
+
+        $this->analyzers['dutch_for_highlighting'] = $this->createCustomAnalyzer(
+            ['standard', 'asciifolding', 'lowercase', 'empty_elision', 'dutch_stemmer', 'dutch_stop']
+        );
+
+        $this->languageAnalyzers['nl'] = 'dutch_for_highlighting';
+
+        return $this;
+    }
+
+    public function addAnalyzersGerman(): Settings
+    {
+        $this->filters['german_stop'] = $this->getFilterStop('_german_');
+        $this->filters['german_stemmer'] = $this->getFilterStemmer('light_german');
+        $this->filters['empty_elision'] = $this->getFilterElision();
+
+        $this->analyzers['german_for_highlighting'] = $this->createCustomAnalyzer(
+            ['standard', 'lowercase', 'empty_elision', 'german_stemmer', 'german_stop']
+        );
+
+        $this->languageAnalyzers['de'] = 'german_for_highlighting';
+
+        return $this;
+    }
+    
+    private function createCustomAnalyzer(array $filters): array 
+    {
+        return [
+            'filter' => $filters,
+            'type' => 'custom',
+            'char_filter' => ['html_strip'],
+            'tokenizer' => 'standard',
+        ];
+    }
+
+    private function getFilterElision(array $articles = ['']): array
+    {
+        return ['type' => 'elision', 'articles' => $articles, 'articles_case' => 'false'];
+    }
+
+    private function getFilterStemmer(string $name): array
+    {
+        return ['name' => $name, 'type' => 'stemmer'];
+    }
+
+    private function getFilterStop(string $stopWords): array
+    {
+        return ['ignore_case' => 'false', 'remove_trailing' => 'true', 'type' => 'stop', 'stopwords' => $stopWords];
+    }
+}

--- a/Elasticsearch/Indexer.php
+++ b/Elasticsearch/Indexer.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace EMS\CoreBundle\Elasticsearch;
+
+use Elasticsearch\Client;
+use EMS\CoreBundle\Elasticsearch\Index\Mappings;
+use EMS\CoreBundle\Elasticsearch\Index\Settings;
+use Psr\Log\LoggerInterface;
+
+class Indexer
+{
+    /** @var Client */
+    private $client;
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(Client $client, LoggerInterface $logger)
+    {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    public function setLogger(LoggerInterface $logger): Indexer
+    {
+        $this->logger = $logger;
+        return $this;
+    }
+
+    public function exists(string $name): bool
+    {
+        return $this->client->indices()->exists(['index' => $name]);
+    }
+
+    public function delete(string $name): void
+    {
+        $params = ['index' => $name];
+        $this->client->indices()->delete($params);
+        $this->logger->info('Deleted index {index}', $params);
+    }
+
+    public function create(string $name, Settings $settings, Mappings $mappings): string
+    {
+        $body = [];
+        if (!$settings->isEmpty()) {
+            $body['settings'] = $settings->toArray();
+        }
+        if (!$mappings->isEmpty()) {
+            $body['mappings'] = $mappings->toArray();
+        }
+
+        $this->client->indices()->create(['index' => $name, 'body' => $body,]);
+        $this->logger->info('Created index {index}', ['index' => $name]);
+
+        return $name;
+    }
+
+    public function atomicSwitch(string $alias, string $index): void
+    {
+        $params = ['name' => $alias];
+        $indices = $this->client->indices();
+        $actions = [['add' => ['index' => $index, 'alias' => $alias]]];
+
+        if ($indices->existsAlias($params)) {
+            $infoAlias = $indices->getAlias($params);
+
+            foreach (array_keys($infoAlias) as $oldIndex) {
+                $actions[] = ['remove' => ['index' => $oldIndex, 'alias' => $alias]];
+            }
+        }
+
+        $indices->updateAliases(['body' => ['actions' => $actions]]);
+
+        $this->logger->info('Alias {alias} is now pointing to {index}', ['alias' => $alias, 'index' => $index]);
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -369,7 +369,7 @@ services:
         tags:
             - { name: form.type }
             
-            
+
 ### regular services
     ems.service.mapping:
         class: EMS\CoreBundle\Service\Mapping
@@ -382,8 +382,11 @@ services:
     ems.service.alias:
         class: EMS\CoreBundle\Service\AliasService
         arguments: ['@app.elasticsearch', '@doctrine']
-    ems.service.bulker:
-        class: EMS\CommonBundle\Elasticsearch\Bulk\Bulker
+    ems.elasticsearch.bulker:
+        class: EMS\CoreBundle\Elasticsearch\Bulker
+        arguments: ['@app.elasticsearch', '@logger']
+    ems.elasticsearch.indexer:
+        class: EMS\CoreBundle\Elasticsearch\Indexer
         arguments: ['@app.elasticsearch', '@logger']
     ems.service.environment: '@EMS\CoreBundle\Service\EnvironmentService'
     EMS\CoreBundle\Service\EnvironmentService:
@@ -459,7 +462,7 @@ services:
             -  { name: console.command }
     ems.contenttype.migrate:
         class: EMS\CoreBundle\Command\MigrateCommand
-        arguments: ['@doctrine', '@logger', '@app.elasticsearch', '@ems.service.bulker', '@ems.service.mapping', '@ems.service.data', '@form.factory', '%ems_core.instance_id%', '@session']
+        arguments: ['@doctrine', '@logger', '@app.elasticsearch', '@ems.elasticsearch.bulker', '@ems.service.mapping', '@ems.service.data', '@form.factory', '%ems_core.instance_id%', '@session']
         tags:
             -  { name: console.command }
     ems.environment.rebuild:
@@ -543,6 +546,9 @@ services:
         class:  EMS\CoreBundle\Security\ApiKeyAuthenticator
         public: false
 
+    #### aliases
+    EMS\CoreBundle\Elasticsearch\Bulker: '@ems.elasticsearch.bulker'
+    EMS\CoreBundle\Elasticsearch\Indexer: '@ems.elasticsearch.indexer'
 
 
 #### Will be mark as deprecated soon

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -917,11 +917,11 @@ class DataService
 				'ouuid' => $ouuid,
 				'contentType' => $contentTypes[0]
 		]);
-		
+
 		/** @var Revision $revision */
 		foreach ($revisions as $revision){
 			$this->lockRevision($revision, true);
-				
+
 			/** @var Environment $environment */
 			foreach ($revision->getEnvironments() as $environment){
 				try{


### PR DESCRIPTION
The common bundle should not contain the elasticsearch bulker class.
Because the clientHelperBundle will never bulk documents to
elasticsearch.

improve: add helper objects for import

- Mapping object
- Settings object
- Indexer for creating an index correct