### PR TITLE
stan lvl 1: getNewestRevision always returns Revision or throws error

### DIFF
--- a/Controller/ContentManagement/CrudController.php
+++ b/Controller/ContentManagement/CrudController.php
@@ -68,24 +68,21 @@ class CrudController extends AppController
         
         try {
             $revision = $this->getDataService()->getNewestRevision($contentType->getName(), $ouuid);
-            
-            $isFound = (isset($revision) && !empty($revision)) ?  true : false;
         } catch (\Exception $e) {
-            $isFound = false;
             if (($e instanceof NotFoundHttpException) or ($e instanceof BadRequestHttpException)) {
                 throw $e;
             } else {
                 $this->addFlash('error', 'The revision for contenttype '. $contentType->getName() .' can not be found. Reason: '.$e->getMessage());
             }
             return $this->render('@EMSCore/ajax/revision.json.twig', [
-                    'success' => $isFound,
+                    'success' => false,
                     'ouuid' => $ouuid,
                     'type' => $contentType->getName(),
             ]);
         }
         
         return $this->render('@EMSCore/ajax/revision.json.twig', [
-                'success' => $isFound,
+                'success' => true,
                 'revision' => $revision->getRawData(),
                 'ouuid' => $revision->getOuuid(),
                 'id' => $revision->getId(),

--- a/Entity/DataField.php
+++ b/Entity/DataField.php
@@ -164,16 +164,14 @@ class DataField implements \ArrayAccess, \IteratorAggregate
 
 
         if ($children) {
-            $temp = new \Doctrine\Common\Collections\ArrayCollection();
+            $temp = new ArrayCollection();
             /** @var FieldType $childField */
             foreach ($children as $childField) {
                 if (!$childField->getDeleted()) {
                     $value = $this->__get('ems_'.$childField->getName());
                     if ($value) {
                         $value->setOrderKey($childField->getOrderKey());
-                        if (isset($value)) {
-                            $temp->add($value);
-                        }
+                        $temp->add($value);
                     }
                 }
             }
@@ -193,7 +191,7 @@ class DataField implements \ArrayAccess, \IteratorAggregate
      */
     public function __construct()
     {
-        $this->children = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->children = new ArrayCollection();
         $this->messages = [];
 
         //TODO: should use the clone method

--- a/Entity/DataField.php
+++ b/Entity/DataField.php
@@ -54,6 +54,8 @@ class DataField implements \ArrayAccess, \IteratorAggregate
     
     private $messages;
 
+    private $marked;
+
     
     public function setChildrenFieldType(FieldType $fieldType)
     {

--- a/Entity/DataField.php
+++ b/Entity/DataField.php
@@ -423,7 +423,7 @@ class DataField implements \ArrayAccess, \IteratorAggregate
      */
     public function setPasswordValue($passwordValue)
     {
-        if (isset($passwordValue)) {
+        if ($passwordValue !== null) {
             $this->setTextValue($passwordValue);
         }
 
@@ -449,7 +449,7 @@ class DataField implements \ArrayAccess, \IteratorAggregate
      */
     public function setResetPasswordValue($resetPasswordValue)
     {
-        if (isset($resetPasswordValue) && $resetPasswordValue) {
+        if ($resetPasswordValue !== null && $resetPasswordValue) {
             $this->setTextValue(null);
         }
 

--- a/Form/DataField/DataFieldType.php
+++ b/Form/DataField/DataFieldType.php
@@ -384,7 +384,7 @@ abstract class DataFieldType extends AbstractType
             if ($parent === null || !isset($restrictionOptions["mandatory_if"]) || $parent->getRawData() === null || (is_array($masterRawData) && !empty($this->resolve($masterRawData, $parent->getRawData(), $restrictionOptions["mandatory_if"])) )) {
                 //Get rawData
                 $rawData = $dataField->getRawData();
-                if (!isset($rawData) || (is_string($rawData) && $rawData=== "") || (is_array($rawData) && count($rawData) === 0) || $rawData === null) {
+                if ($rawData === null || (is_string($rawData) && $rawData=== "") || (is_array($rawData) && count($rawData) === 0)) {
                     $isValidMadatory = false;
                     $dataField->addMessage("Empty field");
                 }

--- a/Form/FieldType/FieldTypeType.php
+++ b/Form/FieldType/FieldTypeType.php
@@ -119,7 +119,7 @@ class FieldTypeType extends AbstractType
             ]);
         }
 
-        if (isset($fieldType) && null != $fieldType->getChildren() && $fieldType->getChildren()->count() > 0) {
+        if ($fieldType !== null && null != $fieldType->getChildren() && $fieldType->getChildren()->count() > 0) {
             $childFound = false;
             /** @var FieldType $field */
             foreach ($fieldType->getChildren() as $idx => $field) {

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -1203,7 +1203,7 @@ class DataService
             $dataFieldType->isValid($dataField, $parent, $masterRawData);
         }
         $isValid = true;
-        if (isset($dataFieldType) && $dataFieldType->isContainer()) {//If datafield is container or type is null => Container => Recursive
+        if ($dataFieldType !== null && $dataFieldType->isContainer()) {//If datafield is container or type is null => Container => Recursive
             $formChildren = $form->all();
             foreach ($formChildren as $child) {
                 if ($child instanceof \Symfony\Component\Form\Form) {
@@ -1216,7 +1216,7 @@ class DataService
             }
         }
 //           $isValid = $isValid && $dataFieldType->isValid($dataField);
-        if (isset($dataFieldType) && !$dataFieldType->isValid($dataField, $parent)) {
+        if ($dataFieldType !== null && !$dataFieldType->isValid($dataField, $parent)) {
             $isValid = false;
             $form->addError(new FormError("This Field is not valid! ".$dataField->getMessages()[0]));
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,4 +3,4 @@ parameters:
         - %currentWorkingDirectory%/vendor/*
         - %currentWorkingDirectory%/DependencyInjection/Configuration.php
         - %currentWorkingDirectory%/Resources/public/js
-    level: 0
+    level: 1


### PR DESCRIPTION
getNewestRevision never returns null nor empty object
The isset was always true, and the isFound is never really used.
(Always true if getNewestRevision passes, always false if error is thrown)

+ line 86 would fail if this code was valid:
$revision->getRawData(),