### PR TITLE
bugfix: choice loader sort already added choices

### DIFF
--- a/Form/Field/ObjectChoiceList.php
+++ b/Form/Field/ObjectChoiceList.php
@@ -91,7 +91,7 @@ class ObjectChoiceList implements ChoiceListInterface
     public function loadAll($types)
     {
         if ($this->loadAll) {
-            $this->choices = $this->objectChoiceCacheService->loadAll($types, $this->circleOnly);
+            $this->objectChoiceCacheService->loadAll($this->choices, $types, $this->circleOnly);
         }
         return $this->choices;
     }

--- a/Service/ObjectChoiceCacheService.php
+++ b/Service/ObjectChoiceCacheService.php
@@ -89,7 +89,7 @@ class ObjectChoiceCacheService
                     //TODO test si > 500...flashbag
 
                     foreach ($items['hits']['hits'] as $hit) {
-                        if(!isset($choices[$hit['_type'].':'.$hit['_id']])) {
+                        if (!isset($choices[$hit['_type'].':'.$hit['_id']])) {
                             $listItem = new ObjectChoiceListItem($hit, $this->contentTypeService->getByName($hit['_type']));
                             $choices[$listItem->getValue()] = $listItem;
                             $this->cache[$hit['_type']][$hit['_id']] = $listItem;


### PR DESCRIPTION
When we load all choices, we don't remember the sort of the already
added choices.