### PR TITLE
bugfix: silent publish not working correctly

### DIFF
--- a/Service/PublishService.php
+++ b/Service/PublishService.php
@@ -182,14 +182,14 @@ class PublishService
                 EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),
                 EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),
                 EmsFields::LOG_ENVIRONMENT_FIELD  => $revision->getContentType()->getEnvironment()->getName(),
-                EmsFields::LOG_OPERATION_DELETE => EmsFields::LOG_OPERATION_UPDATE,
+                EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_UPDATE,
             ]);
         } catch (Exception $e) {
             $this->logger->warning('service.publish.publish_draft_error', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),
                 EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),
                 EmsFields::LOG_ENVIRONMENT_FIELD  => $revision->getContentType()->getEnvironment()->getName(),
-                EmsFields::LOG_OPERATION_DELETE => EmsFields::LOG_OPERATION_UPDATE,
+                EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_UPDATE,
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
                 EmsFields::LOG_EXCEPTION_FIELD => $e,
             ]);


### PR DESCRIPTION
The templates in the skeleton did not refresh after silent publish in
the backend ems. Problem the silent publish action is writing a wrong log
operation (typpo).