### PR TITLE
improvement: export views/templates/singletypeindex

### DIFF
--- a/Controller/ContentManagement/ContentTypeController.php
+++ b/Controller/ContentManagement/ContentTypeController.php
@@ -13,7 +13,6 @@ use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Entity\Form\EditFieldType;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
-use EMS\CoreBundle\Entity\Helper\JsonNormalizer;
 use EMS\CoreBundle\Exception\ElasticmsException;
 use EMS\CoreBundle\Form\DataField\DataFieldType;
 use EMS\CoreBundle\Form\DataField\SubfieldType;
@@ -267,7 +266,7 @@ class ContentTypeController extends AppController
                     $contentType->setDirty(true);
                     $contentType->getFieldType()->updateAncestorReferences($contentType, null);
                     $contentType->setOrderKey($contentTypeRepository->maxOrderKey() + 1);
-
+                    
                     $em->persist($contentType);
                 } else {
                     $contentType = $contentTypeAdded;

--- a/Entity/ContentType.php
+++ b/Entity/ContentType.php
@@ -3,7 +3,6 @@ namespace EMS\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
 use EMS\CoreBundle\Entity\Helper\JsonDeserializer;
 use EMS\CoreBundle\Form\DataField\ContainerFieldType;
@@ -1728,7 +1727,7 @@ class ContentType extends JsonDeserializer implements \JsonSerializable
         $json = new JsonClass(get_object_vars($this), __CLASS__);
         $json->removeProperty('id');
         $json->removeProperty('environment');
-
+        $json->handlePersistentCollections('templates', 'views', 'singleTypeIndexes');
         return $json;
     }
 
@@ -1736,19 +1735,25 @@ class ContentType extends JsonDeserializer implements \JsonSerializable
     {
         switch ($name) {
             case 'templates':
+                /** @var Template $template */
                 foreach ($this->deserializeArray($value) as $template) {
                     $this->addTemplate($template);
+                    $template->setContentType($this);
                 }
                 break;
             case 'views':
+                /** @var View $view */
                 foreach ($this->deserializeArray($value) as $view) {
                     $this->addView($view);
+                    $view->setContentType($this);
                 }
                 break;
 
             case 'singleTypeIndexes':
+                /** @var SingleTypeIndex $index */
                 foreach ($this->deserializeArray($value) as $index) {
                     $this->addSingleTypeIndex($index);
+                    $index->setContentType($this);
                 }
                 break;
             default:

--- a/Entity/Helper/JsonClass.php
+++ b/Entity/Helper/JsonClass.php
@@ -2,6 +2,8 @@
 
 namespace EMS\CoreBundle\Entity\Helper;
 
+use Doctrine\ORM\PersistentCollection;
+
 class JsonClass implements \JsonSerializable
 {
     /** @var string */
@@ -43,6 +45,22 @@ class JsonClass implements \JsonSerializable
     public function updateProperty(string $name, $value)
     {
         $this->properties[$name] = $value;
+    }
+
+    public function hasProperty(string $name): bool
+    {
+        return array_key_exists($name, $this->properties);
+    }
+
+    public function handlePersistentCollections(...$properties)
+    {
+        foreach ($properties as $property) {
+            if (! $this->hasProperty($property) || ! $this->properties[$property] instanceof PersistentCollection) {
+                continue;
+            }
+            $value = $this->properties[$property]->toArray();
+            $this->updateProperty($property, $value);
+        }
     }
 
     /**

--- a/Entity/SingleTypeIndex.php
+++ b/Entity/SingleTypeIndex.php
@@ -220,7 +220,7 @@ class SingleTypeIndex extends JsonDeserializer implements \JsonSerializable
         $json = new JsonClass(get_object_vars($this), __CLASS__);
         $json->removeProperty('id');
         $json->removeProperty('environment');
-
+        $json->removeProperty('contentType');
         return $json;
     }
 }

--- a/Entity/Template.php
+++ b/Entity/Template.php
@@ -940,8 +940,8 @@ class Template extends JsonDeserializer implements \JsonSerializable
     {
         $json = new JsonClass(get_object_vars($this), __CLASS__);
         $json->removeProperty('id');
+        $json->removeProperty('contentType');
         $json->removeProperty('environments');
-
         return $json;
     }
 

--- a/Entity/View.php
+++ b/Entity/View.php
@@ -355,7 +355,7 @@ class View extends JsonDeserializer implements \JsonSerializable
         $json->removeProperty('id');
         $json->removeProperty('created');
         $json->removeProperty('modified');
-
+        $json->removeProperty('contentType');
         return $json;
     }
 }


### PR DESCRIPTION
Export and import of content types is working including views/templates/singletypeindex
BUT all links to "environments" are broken; 

Environments are project specific and to be set manually. Maybe an interface should be added to map imported environments with existing ones? 
And an option that says "use existing environments".