### PR TITLE
Reactivate the propagateDataToComputedField in the ajaxUpdateAction and  editRevisionAction

### DIFF
--- a/Controller/ContentManagement/DataController.php
+++ b/Controller/ContentManagement/DataController.php
@@ -1194,6 +1194,8 @@ class DataController extends AppController
             $em->flush();
 
             $dataService->isValid($form);
+            $dataService->propagateDataToComputedField($form->get('data'), $objectArray, $revision->getContentType(), $revision->getContentType()->getName(), $revision->getOuuid(), false, false);
+
             $session = $request->getSession();
             if ($session instanceof Session) {
                 $session->getFlashBag()->set('warning', []);
@@ -1463,6 +1465,7 @@ class DataController extends AppController
 
 
         $objectArray = $revision->getRawData();
+        $dataService->propagateDataToComputedField($form->get('data'), $objectArray, $revision->getContentType(), $revision->getContentType()->getName(), $revision->getOuuid(), false, false);
 
         if ($revision->getOuuid()) {
             $messageLog = "log.data.revision.start_edit";

--- a/Controller/ContentManagement/DataController.php
+++ b/Controller/ContentManagement/DataController.php
@@ -1193,7 +1193,7 @@ class DataController extends AppController
             $em->persist($revision);
             $em->flush();
 
-            $dataService->isValid($form);
+            $dataService->isValid($form, $revision->getContentType()->getParentField(), $objectArray);
             $dataService->propagateDataToComputedField($form->get('data'), $objectArray, $revision->getContentType(), $revision->getContentType()->getName(), $revision->getOuuid(), false, false);
 
             $session = $request->getSession();
@@ -1442,7 +1442,8 @@ class DataController extends AppController
                 }
             }
         } else {
-            $isValid = $this->getDataService()->isValid($form);
+            $objectArray = $revision->getRawData();
+            $isValid = $this->getDataService()->isValid($form, $revision->getContentType()->getParentField(), $objectArray);
             if (!$isValid) {
                 $logger->warning('log.data.revision.can_finalized', [
                     EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),

--- a/Form/DataField/CollectionFieldType.php
+++ b/Form/DataField/CollectionFieldType.php
@@ -143,7 +143,7 @@ class CollectionFieldType extends DataFieldType
         
         $restrictionOptions = $dataField->getFieldType()->getRestrictionOptions();
         
-        if (!empty($restrictionOptions['min']) && count($dataField->getRawData()) < $restrictionOptions['min']) {
+        if (!empty($restrictionOptions['min']) && ($dataField->getRawData() === null ? 0 : count($dataField->getRawData())) < $restrictionOptions['min']) {
             if ($restrictionOptions['min'] == 1) {
                 $dataField->addMessage("At least 1 item is required");
             } else {

--- a/Resources/translations/EMSCoreBundle.en.yml
+++ b/Resources/translations/EMSCoreBundle.en.yml
@@ -407,6 +407,7 @@ service:
     extract_error: 'An issue has been raised while extracting information from the asset/file ems://asset:%file_hash% : %error_message%'
     persist_error: 'An issue has been raised while persisting the information extracted from the asset/file ems://asset:%file_hash% : %error_message%'
   data:
+    error_with_fields: 'The field %path% is in error with the message %error_message%'
     cant_finalize_field: '%error_message%'
     update_referrers_error: 'It was impossible to update referrers of the document ems://object:%contenttype%:%ouuid%'
     not_a_draft: 'The revision ems://revision:%revision_id% of the document ems://object:%contenttype%:%ouuid% is already finalized'

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -841,53 +841,58 @@ class DataService
                 ]);
             }
         } else {
-            $formErrors = $form->getErrors(true, true);
-            /** @var FormError $formError */
-            foreach ($formErrors as $formError) {
-                $fieldForm = $formError->getOrigin();
-                $dataField = null;
-                while ($fieldForm !== null && !$fieldForm->getNormData() instanceof DataField) {
-                    $fieldForm = $fieldForm->getOrigin()->getParent();
-                }
-
-                if ($fieldForm->getNormData() instanceof DataField) {
-                    /** @var DataField $dataField */
-                    $dataField = $fieldForm->getNormData();
-                    if (! empty($dataField->getMessages())) {
-                        if (sizeof($dataField->getMessages()) === 1) {
-                            $errorMessage = $dataField->getMessages()[0];
-                        } else {
-                            $errorMessage = sprintf('["%s"]', \implode('","', $dataField->getMessages()));
-                        }
-
-                        $fieldName = $fieldForm->getNormData()->getFieldType()->getDisplayOption('label', $fieldForm->getNormData()->getFieldType()->getName());
-                        $errorPath = '';
-
-                        $parent = $fieldForm;
-                        while (($parent = $parent->getParent()) !== null) {
-                            if ($parent->getNormData() instanceof DataField && $parent->getNormData()->getFieldType()->getParent() !== null) {
-                                $errorPath .= $parent->getNormData()->getFieldType()->getDisplayOption('label', $parent->getNormData()->getFieldType()->getName()) . ' > ';
-                            }
-                        }
-                        $errorPath .= $fieldName;
-
-                        $this->logger->warning('service.data.error_with_fields', [
-                            EmsFields::LOG_ERROR_MESSAGE_FIELD => $errorMessage,
-                            EmsFields::LOG_FIELD_IN_ERROR_FIELD => $fieldName,
-                            EmsFields::LOG_PATH_IN_ERROR_FIELD => $errorPath,
-                        ]);
-                    }
-                }
-            }
-
-            $this->logger->warning('service.data.cant_be_finalized', [
-                EmsFields::LOG_REVISION_ID_FIELD => $revision->getId(),
-                EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),
-                EmsFields::LOG_ENVIRONMENT_FIELD => $revision->getContentType()->getEnvironment()->getName(),
-                EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),
-            ]);
+            $this->logFormErrors($revision, $form);
         }
         return $revision;
+    }
+
+    private function logFormErrors(Revision $revision, FormInterface $form)
+    {
+        $formErrors = $form->getErrors(true, true);
+        /** @var FormError $formError */
+        foreach ($formErrors as $formError) {
+            $fieldForm = $formError->getOrigin();
+            $dataField = null;
+            while ($fieldForm !== null && !$fieldForm->getNormData() instanceof DataField) {
+                $fieldForm = $fieldForm->getOrigin()->getParent();
+            }
+
+            if ($fieldForm->getNormData() instanceof DataField) {
+                /** @var DataField $dataField */
+                $dataField = $fieldForm->getNormData();
+                if (! empty($dataField->getMessages())) {
+                    if (sizeof($dataField->getMessages()) === 1) {
+                        $errorMessage = $dataField->getMessages()[0];
+                    } else {
+                        $errorMessage = sprintf('["%s"]', \implode('","', $dataField->getMessages()));
+                    }
+
+                    $fieldName = $fieldForm->getNormData()->getFieldType()->getDisplayOption('label', $fieldForm->getNormData()->getFieldType()->getName());
+                    $errorPath = '';
+
+                    $parent = $fieldForm;
+                    while (($parent = $parent->getParent()) !== null) {
+                        if ($parent->getNormData() instanceof DataField && $parent->getNormData()->getFieldType()->getParent() !== null) {
+                            $errorPath .= $parent->getNormData()->getFieldType()->getDisplayOption('label', $parent->getNormData()->getFieldType()->getName()) . ' > ';
+                        }
+                    }
+                    $errorPath .= $fieldName;
+
+                    $this->logger->warning('service.data.error_with_fields', [
+                        EmsFields::LOG_ERROR_MESSAGE_FIELD => $errorMessage,
+                        EmsFields::LOG_FIELD_IN_ERROR_FIELD => $fieldName,
+                        EmsFields::LOG_PATH_IN_ERROR_FIELD => $errorPath,
+                    ]);
+                }
+            }
+        }
+
+        $this->logger->warning('service.data.cant_be_finalized', [
+            EmsFields::LOG_REVISION_ID_FIELD => $revision->getId(),
+            EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),
+            EmsFields::LOG_ENVIRONMENT_FIELD => $revision->getContentType()->getEnvironment()->getName(),
+            EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),
+        ]);
     }
 
 

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -857,34 +857,36 @@ class DataService
                 $fieldForm = $fieldForm->getOrigin()->getParent();
             }
 
-            if ($fieldForm->getNormData() instanceof DataField) {
-                /** @var DataField $dataField */
-                $dataField = $fieldForm->getNormData();
-                if (! empty($dataField->getMessages())) {
-                    if (sizeof($dataField->getMessages()) === 1) {
-                        $errorMessage = $dataField->getMessages()[0];
-                    } else {
-                        $errorMessage = sprintf('["%s"]', \implode('","', $dataField->getMessages()));
-                    }
+            if (!$fieldForm->getNormData() instanceof DataField) {
+                continue;
+            }
+            /** @var DataField $dataField */
+            $dataField = $fieldForm->getNormData();
+            if (empty($dataField->getMessages())) {
+                continue;
+            }
+            if (sizeof($dataField->getMessages()) === 1) {
+                $errorMessage = $dataField->getMessages()[0];
+            } else {
+                $errorMessage = sprintf('["%s"]', \implode('","', $dataField->getMessages()));
+            }
 
-                    $fieldName = $fieldForm->getNormData()->getFieldType()->getDisplayOption('label', $fieldForm->getNormData()->getFieldType()->getName());
-                    $errorPath = '';
+            $fieldName = $fieldForm->getNormData()->getFieldType()->getDisplayOption('label', $fieldForm->getNormData()->getFieldType()->getName());
+            $errorPath = '';
 
-                    $parent = $fieldForm;
-                    while (($parent = $parent->getParent()) !== null) {
-                        if ($parent->getNormData() instanceof DataField && $parent->getNormData()->getFieldType()->getParent() !== null) {
-                            $errorPath .= $parent->getNormData()->getFieldType()->getDisplayOption('label', $parent->getNormData()->getFieldType()->getName()) . ' > ';
-                        }
-                    }
-                    $errorPath .= $fieldName;
-
-                    $this->logger->warning('service.data.error_with_fields', [
-                        EmsFields::LOG_ERROR_MESSAGE_FIELD => $errorMessage,
-                        EmsFields::LOG_FIELD_IN_ERROR_FIELD => $fieldName,
-                        EmsFields::LOG_PATH_IN_ERROR_FIELD => $errorPath,
-                    ]);
+            $parent = $fieldForm;
+            while (($parent = $parent->getParent()) !== null) {
+                if ($parent->getNormData() instanceof DataField && $parent->getNormData()->getFieldType()->getParent() !== null) {
+                    $errorPath .= $parent->getNormData()->getFieldType()->getDisplayOption('label', $parent->getNormData()->getFieldType()->getName()) . ' > ';
                 }
             }
+            $errorPath .= $fieldName;
+
+            $this->logger->warning('service.data.error_with_fields', [
+                EmsFields::LOG_ERROR_MESSAGE_FIELD => $errorMessage,
+                EmsFields::LOG_FIELD_IN_ERROR_FIELD => $fieldName,
+                EmsFields::LOG_PATH_IN_ERROR_FIELD => $errorPath,
+            ]);
         }
 
         $this->logger->warning('service.data.cant_be_finalized', [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"caxy/php-htmldiff": "^0.1",
 		"doctrine/doctrine-migrations-bundle" : "^1.3",
 		"dompdf/dompdf": "^0.8",
-		"elasticms/common-bundle": "~1.7.0",
+		"elasticms/common-bundle": ">=1.7.4",
 		"guzzlehttp/guzzle" : "^6.3",
 		"maennchen/zipstream-php" : "^0.5",
 		"psr/simple-cache": "^1.0",


### PR DESCRIPTION
With the commit e8776c9c649243b5733691258bfaaf92f60d9f67 the propagateDataToComputedField was removed from the ajaxUpdateAction and  editRevisionAction as those calls was sending emails or incrementing counters. But this commit has disabled the live/ajax error messages.