### PR TITLE
Support both term and match searches in the referrers search

### DIFF
--- a/Controller/ContentManagement/DataController.php
+++ b/Controller/ContentManagement/DataController.php
@@ -492,14 +492,19 @@ class DataController extends AppController
         $searchForm->setSortOrder('asc');
 
         $filter = $searchForm->getFilters()[0];
-        $filter->setBooleanClause('must');
+        $filter->setBooleanClause('should');
         $filter->setField($revision->getContentType()->getRefererFieldName());
         $filter->setPattern($type . ':' . $ouuid);
-        if (empty($revision->getContentType()->getRefererFieldName())) {
-            $filter->setOperator('match_and');
-        } else {
-            $filter->setOperator('term');
-        }
+        $filter->setOperator('term');
+
+        $filter = new SearchFilter();
+        $filter->setBooleanClause('should');
+        $filter->setField($revision->getContentType()->getRefererFieldName());
+        $filter->setPattern($type . ':' . $ouuid);
+        $filter->setOperator('match_and');
+        $searchForm->addFilter($filter);
+
+        $searchForm->setMinimumShouldMatch(1);
 
         $refParams = [
             '_source' => false,
@@ -515,7 +520,6 @@ class DataController extends AppController
             'availableEnv' => $availableEnv,
             'object' => $revision->getObject($objectArray),
             'referrers' => $client->search($refParams),
-            'referrersFilter' => $filter,
             'page' => $page,
             'lastPage' => $lastPage,
             'counter' => $counter,
@@ -523,6 +527,7 @@ class DataController extends AppController
             'dataFields' => $dataFields,
             'compareData' => $compareData,
             'compareId' => $compareId,
+            'referrersForm' => $searchForm,
         ]);
     }
 

--- a/Controller/ContentManagement/DataController.php
+++ b/Controller/ContentManagement/DataController.php
@@ -494,13 +494,13 @@ class DataController extends AppController
         $filter = $searchForm->getFilters()[0];
         $filter->setBooleanClause('should');
         $filter->setField($revision->getContentType()->getRefererFieldName());
-        $filter->setPattern($type . ':' . $ouuid);
+        $filter->setPattern(sprintf('%s:%s', $type, $ouuid));
         $filter->setOperator('term');
 
         $filter = new SearchFilter();
         $filter->setBooleanClause('should');
         $filter->setField($revision->getContentType()->getRefererFieldName());
-        $filter->setPattern($type . ':' . $ouuid);
+        $filter->setPattern(sprintf('"%s:%s"', $type, $ouuid));
         $filter->setOperator('match_and');
         $searchForm->addFilter($filter);
 

--- a/Resources/views/data/revisions-data.html.twig
+++ b/Resources/views/data/revisions-data.html.twig
@@ -224,14 +224,10 @@
 					
 					<div class="box-footer">
 						<div class="btn-group">
-							<a href="{{ path('elasticsearch.search', {
-			            		'search_form[sortBy]': '_uid',
-			            		'search_form[sortOrder]': 'asc',
-			            		'search_form[filters][0][booleanClause]' : referrersFilter.booleanClause,
-			            		'search_form[filters][0][field]' : referrersFilter.field,
-			            		'search_form[filters][0][operator]' : referrersFilter.operator,
-			            		'search_form[filters][0][pattern]' : referrersFilter.pattern
-								} ) }}" class="btn btn-primary"><i class="fa fa-search"></i> {{ 'All linked documents' }}</a>
+							<a href="{{ path('ems_search', {'search_form': referrersForm} ) }}" class="btn btn-primary">
+								<i class="fa fa-search"></i>
+								{{ 'All linked documents' }}
+							</a>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
With elasticsearch the _all doesn't exits any more. Nevertheless we still would like to use a copy to field to search referrers. So base on the referrers fields we must do a should query with a term query and a match query