### PR TITLE
fix(newDocument): merge default and circles

### DIFF
--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -1194,7 +1194,7 @@ class DataService
                 $options = $fieldType->getDisplayOptions();
                 if (isset($options['multiple']) && $options['multiple']) {
                     //merge all my circles with the default value
-                    $circles = $raw[$contentType->getCirclesField()] ?? [];
+                    $circles = $revision->getRawData()[$contentType->getCirclesField()] ?? [];
                     if (isset($options['defaultValue'])) {
                         $defaultValue = json_decode($options['defaultValue']);
                         if (!\is_array($defaultValue)) {

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -1121,7 +1121,7 @@ class DataService
     /**
      * @param ContentType $contentType
      * @param string|null $ouuid
-     * @param array|null $rawData
+     * @param array<mixed>|null $rawData
      * @return Revision
      * @throws DuplicateOuuidException
      * @throws HasNotCircleException
@@ -1194,15 +1194,16 @@ class DataService
                 $options = $fieldType->getDisplayOptions();
                 if (isset($options['multiple']) && $options['multiple']) {
                     //merge all my circles with the default value
-                    $circles = [];
+                    $circles = $raw[$contentType->getCirclesField()] ?? [];
                     if (isset($options['defaultValue'])) {
-                        $circles = json_decode($options['defaultValue']);
-                        if (!is_array($circles)) {
-                            $circles = [$circles];
+                        $defaultValue = json_decode($options['defaultValue']);
+                        if (!is_array($defaultValue)) {
+                            $defaultValue = [$defaultValue];
                         }
+                        $circles = array_merge($circles, $defaultValue);
                     }
                     $circles = array_merge($circles, $user->getCircles());
-                    $revision->setRawData([$contentType->getCirclesField() => $circles]);
+                    $revision->setRawData(array_merge($revision->getRawData(), [$contentType->getCirclesField() => $circles]));
                     $revision->setCircles($circles);
                 } else {
                     //set first of my circles

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -1197,13 +1197,13 @@ class DataService
                     $circles = $raw[$contentType->getCirclesField()] ?? [];
                     if (isset($options['defaultValue'])) {
                         $defaultValue = json_decode($options['defaultValue']);
-                        if (!is_array($defaultValue)) {
+                        if (!\is_array($defaultValue)) {
                             $defaultValue = [$defaultValue];
                         }
-                        $circles = array_merge($circles, $defaultValue);
+                        $circles = \array_merge($circles, $defaultValue);
                     }
-                    $circles = array_merge($circles, $user->getCircles());
-                    $revision->setRawData(array_merge($revision->getRawData(), [$contentType->getCirclesField() => $circles]));
+                    $circles = \array_merge($circles, $user->getCircles());
+                    $revision->setRawData(\array_merge($revision->getRawData(), [$contentType->getCirclesField() => $circles]));
                     $revision->setCircles($circles);
                 } else {
                     //set first of my circles

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -1188,7 +1188,11 @@ class DataService
 
         if ($contentType->getCirclesField()) {
             if (isset($revision->getRawData()[$contentType->getCirclesField()])) {
-                $revision->setCircles($revision->getRawData()[$contentType->getCirclesField()]);
+                if (\is_array($revision->getRawData()[$contentType->getCirclesField()])) {
+                    $revision->setCircles($revision->getRawData()[$contentType->getCirclesField()]);
+                } else {
+                    $revision->setCircles([$revision->getRawData()[$contentType->getCirclesField()]]);
+                }
             } else {
                 $fieldType = $contentType->getFieldType()->getChildByPath($contentType->getCirclesField());
                 if ($fieldType) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9950,10 +9950,6 @@ parameters:
 			count: 2
 			path: Service/DataService.php
 
-		-
-			message: "#^Method EMS\\\\CoreBundle\\\\Service\\\\DataService\\:\\:newDocument\\(\\) has parameter \\$rawData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Service/DataService.php
 
 		-
 			message: "#^Parameter \\#1 \\$ouuid of method EMS\\\\CoreBundle\\\\Entity\\\\Revision\\:\\:setOuuid\\(\\) expects string, string\\|null given\\.$#"


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Need to keep defaults value of CT type (in edit of CT). 
If not default value for circles field, set circles of user in circles field else use default value only