### PR TITLE
fix: ems rebuild switch not working

### DIFF
--- a/Command/RebuildCommand.php
+++ b/Command/RebuildCommand.php
@@ -161,11 +161,11 @@ class RebuildCommand extends EmsCommand
 
         /** @var ContentType $contentType */
         foreach ($contentTypes as $contentType) {
-            $environment = $contentType->getEnvironment();
-            if ($environment === null) {
+            $contentTypeEnvironment = $contentType->getEnvironment();
+            if ($contentTypeEnvironment === null) {
                 throw new \RuntimeException('Unexpected null environment');
             }
-            if (!$contentType->getDeleted() && $contentType->getEnvironment() && $environment->getManaged()) {
+            if (!$contentType->getDeleted() && $contentType->getEnvironment() && $contentTypeEnvironment->getManaged()) {
                 if ($this->singleTypeIndex) {
                     $indexName = $this->environmentService->getNewIndexName($environment, $contentType);
                     $indexes[] = $indexName;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

Rebuilding preview resulted in:

The alias template is now pointing to : ems_preview_20201030_101539

The environment variable was overriden in the for loop.
Causing the environment tobe the default env of the last contentType.