### PR TITLE
feat: role_user_management need manage circles

### DIFF
--- a/Controller/ContentManagement/DataController.php
+++ b/Controller/ContentManagement/DataController.php
@@ -247,7 +247,7 @@ class DataController extends AppController
         /** @var RevisionRepository $revisionRep */
         $revisionRep = $em->getRepository('EMSCoreBundle:Revision');
 
-        $revisions = $revisionRep->findInProgresByContentType($contentType, $this->getUserService()->getCurrentUser()->getCircles(), $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN'));
+        $revisions = $revisionRep->findInProgresByContentType($contentType, $this->getUserService()->getCurrentUser()->getCircles(), $this->get('security.authorization_checker')->isGranted('ROLE_USER_MANAGEMENT'));
 
 
         return $this->render('@EMSCore/data/draft-in-progress.html.twig', [

--- a/Controller/ElasticsearchController.php
+++ b/Controller/ElasticsearchController.php
@@ -490,7 +490,7 @@ class ElasticsearchController extends AppController
                 }
             }
 
-            if ($circleOnly && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
+            if ($circleOnly && !$this->get('security.authorization_checker')->isGranted('ROLE_USER_MANAGEMENT')) {
                 /**@var UserInterface $user */
                 $user = $this->getUser();
                 $circles = $user->getCircles();

--- a/Controller/TwigElementsController.php
+++ b/Controller/TwigElementsController.php
@@ -23,7 +23,7 @@ class TwigElementsController extends AbstractController
         $revisionRepository = $this->getDoctrine()->getRepository('EMSCoreBundle:Revision');
         $user = $userService->getCurrentUser();
 
-        $temp = $revisionRepository->draftCounterGroupedByContentType($user->getCircles(), $this->isGranted('ROLE_ADMIN'));
+        $temp = $revisionRepository->draftCounterGroupedByContentType($user->getCircles(), $this->isGranted('ROLE_USER_MANAGEMENT'));
         foreach ($temp as $item) {
             $draftCounterGroupedByContentType[$item["content_type_id"]] = $item["counter"];
         }

--- a/Repository/NotificationRepository.php
+++ b/Repository/NotificationRepository.php
@@ -320,7 +320,7 @@ class NotificationRepository extends \Doctrine\ORM\EntityRepository
                     $templateIds[] = $template->getId();
                 } else {
                     $commonCircle = array_intersect($circles, $template->getCirclesTo());
-                    if (!empty($commonCircle) || $this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+                    if (!empty($commonCircle) || $this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT')) {
                         $templateIds[] = $template->getId();
                     }
                 }

--- a/Service/DataService.php
+++ b/Service/DataService.php
@@ -214,7 +214,7 @@ class DataService
         if (!empty($publishEnv) && !$this->authorizationChecker->isGranted($revision->getContentType()->getPublishRole() ?: 'ROLE_PUBLISHER')) {
             throw new PrivilegeException($revision, 'You don\'t have publisher role for this content');
         }
-        if (!empty($publishEnv) && is_object($publishEnv) && !empty($publishEnv->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_ADMIN') && !$this->appTwig->inMyCircles($publishEnv->getCircles())) {
+        if (!empty($publishEnv) && is_object($publishEnv) && !empty($publishEnv->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && !$this->appTwig->inMyCircles($publishEnv->getCircles())) {
             throw new PrivilegeException($revision, 'You don\'t share any circle with this content');
         }
         if (empty($publishEnv) && !empty($revision->getContentType()->getCirclesField()) && !empty($revision->getRawData()[$revision->getContentType()->getCirclesField()])) {
@@ -1230,7 +1230,7 @@ class DataService
         $userCircles = $this->userService->getCurrentUser()->getCircles();
         $environment = $contentType->getEnvironment();
         $environmentCircles = $environment->getCircles();
-        if (!$this->authorizationChecker->isGranted('ROLE_ADMIN') && !empty($environmentCircles)) {
+        if (!$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && !empty($environmentCircles)) {
             if (empty($userCircles)) {
                 throw new HasNotCircleException($environment);
             }

--- a/Service/EnvironmentService.php
+++ b/Service/EnvironmentService.php
@@ -293,7 +293,7 @@ class EnvironmentService
 
     public function getAllInMyCircle()
     {
-        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+        if ($this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT')) {
             return $this->getEnvironments();
         };
 

--- a/Service/ObjectChoiceCacheService.php
+++ b/Service/ObjectChoiceCacheService.php
@@ -71,7 +71,7 @@ class ObjectChoiceCacheService
                         ];
                     }
 
-                    if ($circleOnly && !$this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+                    if ($circleOnly && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT')) {
                         /** @var UserInterface $user */
                         $user = $this->tokenStorage->getToken()->getUser();
                         $circles = $user->getCircles();

--- a/Service/PublishService.php
+++ b/Service/PublishService.php
@@ -208,7 +208,7 @@ class PublishService
     {
         if (!$command) {
             $user = $this->userService->getCurrentUser();
-            if (!empty($environment->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_ADMIN') && empty(array_intersect($environment->getCircles(), $user->getCircles()))) {
+            if (!empty($environment->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && empty(array_intersect($environment->getCircles(), $user->getCircles()))) {
                 $this->logger->warning('service.publish.not_in_circles', [
                     EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),
                     EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),
@@ -317,7 +317,7 @@ class PublishService
         
         if (!$command) {
             $user = $this->userService->getCurrentUser();
-            if (!empty($environment->getCircles() && !$this->authorizationChecker->isGranted('ROLE_ADMIN') && empty(array_intersect($environment->getCircles(), $user->getCircles())))) {
+            if (!empty($environment->getCircles() && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && empty(array_intersect($environment->getCircles(), $user->getCircles())))) {
                 $this->logger->warning('service.publish.not_in_circles', [
                     EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType()->getName(),
                     EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),

--- a/Twig/AppExtension.php
+++ b/Twig/AppExtension.php
@@ -801,7 +801,7 @@ class AppExtension extends AbstractExtension
             return true;
         }
 
-        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+        if ($this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT')) {
             return true;
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Now we have a role_user_management, and circles are define in users. 
It's better to set role_user_manager for everything related to circles. 