### PR TITLE
chore(phpstan): fix config paths

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -5,8 +5,8 @@ if (!file_exists(__DIR__.'/src')) {
 }
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-    ->exclude('vendor')
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
     ->exclude('tests/tmp')
 ;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   # Run PHPCS
   - if [[ "$SNIFF" == "1" ]]; then vendor/bin/php-cs-fixer fix --dry-run --diff; fi
   # Run PHPStan
-  - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpstan analyse .; fi
+  - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpstan analyse; fi

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
 	},
 	"scripts": {
 		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse .",
+		"phpstan": "phpstan analyse",
 		"phpunit": "phpunit"
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,8 +2,9 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    paths:
+        - %currentWorkingDirectory%/src
     excludes_analyse:
-        - %currentWorkingDirectory%/vendor/*
         - %currentWorkingDirectory%/src/DependencyInjection/Configuration.php
         - %currentWorkingDirectory%/src/Resources/DoctrineMigrations
         - %currentWorkingDirectory%/src/Resources/public/js


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

- Locally node_modules was also scanned.
- Phpcs only scan src dir
- Change composer phpstan remove . (use config)
- Change travis config remove .