### PR TITLE
fix: the string mapping is deprecated since es5 and replaced by text

### DIFF
--- a/src/Form/DataField/JsonMenuNestedEditorFieldType.php
+++ b/src/Form/DataField/JsonMenuNestedEditorFieldType.php
@@ -78,11 +78,11 @@ class JsonMenuNestedEditorFieldType extends DataFieldType
     /**
      * @param bool $withPipeline
      *
-     * @return array<string, array{'type': 'string'}>
+     * @return array<string, array{type: string}>
      */
     public function generateMapping(FieldType $current, $withPipeline): array
     {
-        return [$current->getName() => ['type' => 'string']];
+        return [$current->getName() => ['type' => 'text']];
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	
