### PR TITLE
fix: es7 remove filter standard

### DIFF
--- a/src/Entity/Analyzer.php
+++ b/src/Entity/Analyzer.php
@@ -148,14 +148,15 @@ class Analyzer extends JsonDeserializer implements \JsonSerializable
         return $this;
     }
 
-    /**
-     * Get options.
-     *
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(string $esVersion): array
     {
-        return $this->options;
+        $options = $this->options ?? [];
+
+        if (\version_compare($esVersion, '7.0') >= 0) {
+            $options['filter'] = \array_filter($options['filter'], function (string $f) { return 'standard' !== $f; });
+        }
+
+        return $options;
     }
 
     /**

--- a/src/Service/EnvironmentService.php
+++ b/src/Service/EnvironmentService.php
@@ -192,6 +192,7 @@ class EnvironmentService
      */
     public function getIndexAnalysisConfiguration(): array
     {
+        $esVersion = $this->elasticaService->getVersion();
         $filters = [];
 
         /** @var FilterRepository $filterRepository */
@@ -207,10 +208,10 @@ class EnvironmentService
         $analyzerRepository = $this->doctrine->getRepository('EMSCoreBundle:Analyzer');
         /** @var Analyzer $analyzer */
         foreach ($analyzerRepository->findAll() as $analyzer) {
-            $analyzers[$analyzer->getName()] = $analyzer->getOptions();
+            $analyzers[$analyzer->getName()] = $analyzer->getOptions($esVersion);
         }
 
-        $settingsSectionLabel = \version_compare($this->elasticaService->getVersion(), '7.0') >= 0 ? 'settings' : 'index';
+        $settingsSectionLabel = \version_compare($esVersion, '7.0') >= 0 ? 'settings' : 'index';
 
         return [
             $settingsSectionLabel => [


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

https://stackoverflow.com/questions/58202006/elasticsearch-7-the-standard-token-filter-has-been-removed

The standard token filter has been removed because it does not change
anything in the stream.