### PR TITLE
fix: empty cluster error aggregation

### DIFF
--- a/src/Service/AliasService.php
+++ b/src/Service/AliasService.php
@@ -183,10 +183,18 @@ class AliasService
         $terms->setSize(2000);
         $search->addAggregation($terms);
         $search->setSize(0);
-        $aggregation = $this->elasticaService->search($search)->getAggregation(self::COUNTER_AGGREGATION);
-        if (0 !== ($aggregation['sum_other_doc_count'] ?? 0) || \count($aggregation['buckets'] ?? []) >= 2000) {
-            $this->logger->warning('service.alias.too_many_indexes');
+
+        $resultSet = $this->elasticaService->search($search);
+
+        if ($resultSet->hasAggregations()) {
+            $aggregation = $resultSet->getAggregation(self::COUNTER_AGGREGATION);
+            if (0 !== ($aggregation['sum_other_doc_count'] ?? 0) || \count($aggregation['buckets'] ?? []) >= 2000) {
+                $this->logger->warning('service.alias.too_many_indexes');
+            }
+        } else {
+            $aggregation = [];
         }
+
         $this->counterIndexes = [];
         foreach ($aggregation['buckets'] ?? [] as $bucket) {
             $index = $bucket['key'] ?? '';


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The following error get throwen when doing an ems:env:rebuild on an
empty elasticSearch cluster.

This result set does not contain an aggregation named
counter_aggregation.