### PR TITLE
fix: add _all field on rebuild

### DIFF
--- a/src/Form/DataField/DateRangeFieldType.php
+++ b/src/Form/DataField/DateRangeFieldType.php
@@ -139,6 +139,7 @@ class DateRangeFieldType extends DataFieldType
         if (!isset($option['mappingOptions'])) {
             return false;
         }
+
         return !$option['mappingOptions']['nested'] ?? false;
     }
 

--- a/src/Service/ChannelService.php
+++ b/src/Service/ChannelService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Service;
 
-use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\CoreBundle\Entity\Channel;
 use EMS\CoreBundle\Repository\ChannelRepository;
 use Psr\Log\LoggerInterface;

--- a/src/Service/Mapping.php
+++ b/src/Service/Mapping.php
@@ -100,6 +100,11 @@ class Mapping
                 'enabled' => true,
             ];
         } else {
+            foreach ($out['properties'] as $name => &$options) {
+                if (\in_array($options['type'], ['text', 'keyword'], true)) {
+                    $options['copy_to'] = array_unique(array_merge(['_all'], $options['copy_to'] ?? []));
+                }
+            }
             $out['properties'] = \array_merge(['_all' => ['type' => 'text']], $out['properties']);
         }
 

--- a/src/Service/Mapping.php
+++ b/src/Service/Mapping.php
@@ -99,7 +99,7 @@ class Mapping
                 'store' => true,
                 'enabled' => true,
             ];
-        } else {
+        } elseif (\version_compare($this->elasticaService->getVersion(), '7.0') < 0) {
             foreach ($out['properties'] as $name => &$options) {
                 if (\in_array($options['type'], ['text', 'keyword'], true)) {
                     $options['copy_to'] = array_unique(array_merge(['_all'], $options['copy_to'] ?? []));

--- a/src/Service/Mapping.php
+++ b/src/Service/Mapping.php
@@ -90,15 +90,17 @@ class Mapping
             'properties' => [],
         ];
 
+        if (null != $contentType->getFieldType()) {
+            $out['properties'] = $this->fieldTypeType->generateMapping($contentType->getFieldType(), $withPipeline);
+        }
+
         if ($this->elasticsearchService->withAllMapping()) {
             $out['_all'] = [
                 'store' => true,
                 'enabled' => true,
             ];
-        }
-
-        if (null != $contentType->getFieldType()) {
-            $out['properties'] = $this->fieldTypeType->generateMapping($contentType->getFieldType(), $withPipeline);
+        } else {
+            $out['properties'] = \array_merge(['_all' => ['type' => 'text']], $out['properties']);
         }
 
         $out['properties'] = \array_merge(


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

On a es7 cluster we do not have the _all anymore, so we add it on rebuild.
Fields we want to search on we have to define copy_to -> _all.
