### PR TITLE
Release 1.14.32

### DIFF
--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -305,7 +305,8 @@ class ElasticsearchController extends AppController
         $page = \intval($request->query->get('page', 1));
         $environments = $request->query->get('environment', null);
         $types = $request->query->get('type', null);
-        $searchId = $request->query->get('searchId', null);
+        $requestSearchId = $request->query->get('searchId', null);
+        $searchId = null !== $requestSearchId ? \intval($requestSearchId) : null;
         $category = $request->query->get('category', null);
         $assetName = $request->query->get('asset_name', false);
         $circleOnly = $request->query->get('circle', false);
@@ -399,10 +400,10 @@ class ElasticsearchController extends AppController
 
         $commonSearch->setFrom(($page - 1) * $pageSize);
         $commonSearch->setSize($pageSize);
-        $results = $elasticaService->search($commonSearch);
+        $response = CommonResponse::fromResultSet($elasticaService->search($commonSearch));
 
         return $this->render('@EMSCore/elasticsearch/search.json.twig', [
-            'results' => $results->getResponse()->getData(),
+            'results' => $response,
             'types' => $allTypes,
         ]);
     }

--- a/src/DependencyInjection/EMSCoreExtension.php
+++ b/src/DependencyInjection/EMSCoreExtension.php
@@ -130,8 +130,8 @@ class EMSCoreExtension extends Extension implements PrependExtensionInterface
             $container->prependExtensionConfig('twig', [
                 'globals' => $globals,
                 'form_themes' => [
-                    '@EMSCore/form/fields.html.twig',
                     '@EMSCore/form/forms.html.twig',
+                    '@EMSCore/form/fields.html.twig',
                 ],
             ]);
         }

--- a/src/DependencyInjection/EMSCoreExtension.php
+++ b/src/DependencyInjection/EMSCoreExtension.php
@@ -130,7 +130,6 @@ class EMSCoreExtension extends Extension implements PrependExtensionInterface
             $container->prependExtensionConfig('twig', [
                 'globals' => $globals,
                 'form_themes' => [
-                    '@EMSCore/form/forms.html.twig',
                     '@EMSCore/form/fields.html.twig',
                 ],
             ]);

--- a/src/Resources/views/channel/index.html.twig
+++ b/src/Resources/views/channel/index.html.twig
@@ -11,6 +11,7 @@
 {% endblock %}
 
 {% block body %}
+	{% form_theme form '@EMSCore/form/forms.html.twig' %}
 	{{ form(form, {
 		reorder_label: 'channel.index.reorder',
 		add_label: 'channel.add.title'

--- a/src/Resources/views/elasticsearch/search.json.twig
+++ b/src/Resources/views/elasticsearch/search.json.twig
@@ -1,36 +1,44 @@
-{
-	"total_count": {{results.hits.total}},
-	"incomplete_results": {{ (results.hits.total != results.hits.hits|length)|json_encode() }},
-	"items": [
-	{% for item in results.hits.hits %}
-		{% if loop.index > 1 %},{% endif %}
-		{
-			"id": {{ (item._type~':'~item._id)|json_encode()|raw }},
-			"type": {{ item._type|json_encode()|raw }},
-			"ouuid": {{ item._id|json_encode()|raw }},
-			{% if attribute(types, item._type).colorField is defined %}
-				{% set colorField = attribute(types, item._type).colorField %}
-				{% if attribute(item._source, colorField) is defined %}
-					"color": {{ attribute(item._source, colorField)|json_encode()|raw }},
-				{% endif %}
-			{% endif %}
-			{% set icon = '<i class="fa fa-question"></i> ' %}
+{% apply spaceless %}
+	{% set items = [] %}
+	{% for doc in results.documents %}
+		{%- set item = {
+			"id": (doc.getEmsId),
+			"type": (doc.getContentType),
+			"ouuid": (doc.getId)
+		}  -%}
 
-			{% if attribute(types, item._type).icon is defined %}
-				{% set icon = ('<i class=\"' ~ attribute(types, item._type).icon ~ '\"> </i> ') %}
+		{% if attribute(types, doc.getContentType).colorField is defined %}
+			{% set colorField = attribute(types, doc.getContentType).colorField %}
+
+			{% if attribute(doc.source, colorField) is defined %}
+				{% set item = item|merge({ "color": (attribute(item.source, colorField)) }) %}
 			{% endif %}
-						
-			{% if attribute(types, item._type).labelField is defined %}
-				{% set labelField = attribute(types, item._type).labelField %}
-				{% if attribute(item._source, labelField) is defined %}
-					"text": {{ (icon~attribute(item._source, labelField))|json_encode()|raw }}
+		{% endif %}
+
+		{% set icon = '<i class="fa fa-question"></i> ' %}
+
+		{% if attribute(types, doc.getContentType).icon is defined %}
+			{% set icon = ('<i class=\"' ~ attribute(types, doc.getContentType).icon ~ '\"> </i> ') %}
+		{% endif %}
+
+			{% if attribute(types, doc.getContentType).labelField is defined %}
+				{% set labelField = attribute(types, doc.getContentType).labelField %}
+				{% if attribute(doc.source, labelField) is defined %}
+					{% set item = item|merge({ "text": (attribute(doc.source, labelField)) }) %}
 				{% else %}
-					"text": {{ (icon~item._id)|json_encode()|raw }}
+					{% set item = item|merge({ "text": item.id }) %}
 				{% endif %}
 			{% else %}
-				"text": {{ (icon~item._id)|json_encode()|raw }}
+				{% set item = item|merge({ "text": item.id }) %}
 			{% endif %}
-		}
+
+		{% set items = items|merge([item]) %}
 	{% endfor %}
-	]
-}
+
+	{% set json = {
+		"total_count": (results.total),
+		"incomplete_results": (results.total != results.totalDocuments),
+		"items": items,
+	} %}
+{% endapply %}
+{{ json|default([])|json_encode|raw }}

--- a/src/Resources/views/form/forms.html.twig
+++ b/src/Resources/views/form/forms.html.twig
@@ -1,4 +1,4 @@
-{% use "bootstrap_3_layout.html.twig" %}
+{% use "@EMSCore/form/fields.html.twig" %}
 {% trans_default_domain 'EMSCoreBundle' %}
 {% block emsco_form_table_type_widget %}
     {% set table = form.vars.data %}


### PR DESCRIPTION
* fix: dataLink type search broken

Pass Common response to twig template
Clean twig template

* fix: jsonMenuNested modals not working

The channel features introduce a new formTemplate.
JsonMenuNested modals are defined in the form_end, but this was not called anymore!

Because @EMSCore/form/forms.html.twig is more important it should come at the end of the array!

Symfony documentation:
You can pass multiple themes to this option because sometimes form themes only redefine a few elements. This way, if some theme doesn’t override some element, Symfony looks up in the other themes.

The order of the themes in the twig.form_themes option is important. Each theme overrides all the previous themes, so you must put the most important themes at the end of the list.

* fix: remark and phpcs

Co-authored-by: David Mattei <david.mattei@smals.be>

|Q              |A  |
|---------------|---|
|Bug fix?       ||
|New feature?   ||	
|BC breaks?     ||	
|Deprecations?  ||	
|Fixed tickets  ||	

Replace_With_One_Paragraph_Description