### PR TITLE
fix: remove the forms.html.twig as global form theme

### DIFF
--- a/src/DependencyInjection/EMSCoreExtension.php
+++ b/src/DependencyInjection/EMSCoreExtension.php
@@ -130,7 +130,6 @@ class EMSCoreExtension extends Extension implements PrependExtensionInterface
             $container->prependExtensionConfig('twig', [
                 'globals' => $globals,
                 'form_themes' => [
-                    '@EMSCore/form/forms.html.twig',
                     '@EMSCore/form/fields.html.twig',
                 ],
             ]);

--- a/src/Resources/views/channel/index.html.twig
+++ b/src/Resources/views/channel/index.html.twig
@@ -11,6 +11,7 @@
 {% endblock %}
 
 {% block body %}
+	{% form_theme form '@EMSCore/form/forms.html.twig' %}
 	{{ form(form, {
 		reorder_label: 'channel.index.reorder',
 		add_label: 'channel.add.title'

--- a/src/Resources/views/form/forms.html.twig
+++ b/src/Resources/views/form/forms.html.twig
@@ -1,4 +1,4 @@
-{% use "bootstrap_3_layout.html.twig" %}
+{% use "@EMSCore/form/fields.html.twig" %}
 {% trans_default_domain 'EMSCoreBundle' %}
 {% block emsco_form_table_type_widget %}
     {% set table = form.vars.data %}


### PR DESCRIPTION


|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

the forms.html.twig is not a theme template. It is a specific twig for forms. It has to be loaded only when it's necessary, but it use the core theme as ancestor