### PR TITLE
HOTFIX: rebuild failing

### DIFF
--- a/src/Entity/Analyzer.php
+++ b/src/Entity/Analyzer.php
@@ -160,7 +160,7 @@ class Analyzer extends JsonDeserializer implements \JsonSerializable
             $options['filter'] = \array_filter($options['filter'], function (string $f) { return 'standard' !== $f; });
         }
 
-        return $options;
+        return \array_filter($options);
     }
 
     /**

--- a/src/Entity/Analyzer.php
+++ b/src/Entity/Analyzer.php
@@ -156,7 +156,7 @@ class Analyzer extends JsonDeserializer implements \JsonSerializable
             return $options;
         }
 
-        if (\version_compare($esVersion, '7.0') >= 0) {
+        if (isset($options['filter']) && \version_compare($esVersion, '7.0') >= 0) {
             $options['filter'] = \array_filter($options['filter'], function (string $f) { return 'standard' !== $f; });
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Filter fix for es7 was not working for analyzer without filters.
And also failing when putting empty array as filter option