### PR TITLE
fix: recompute with option id not working

### DIFF
--- a/src/Command/LockCommand.php
+++ b/src/Command/LockCommand.php
@@ -42,7 +42,7 @@ class LockCommand extends Command
             ->addOption('user', null, InputOption::VALUE_REQUIRED, 'lock username', 'EMS_COMMAND')
             ->addOption('force', null, InputOption::VALUE_NONE, 'do not check for already locked revisions')
             ->addOption('if-empty', null, InputOption::VALUE_NONE, 'lock if there are no pending locks for the same user')
-            ->addOption('id', null, InputOption::VALUE_OPTIONAL, 'lock a specific id')
+            ->addOption('ouuid', null, InputOption::VALUE_OPTIONAL, 'lock a specific ouuid', null)
         ;
     }
 
@@ -80,7 +80,8 @@ class LockCommand extends Command
             return 0;
         }
 
-        $rows = $this->revisionRepository->lockRevisions($contentType, $until, $by, $force, $input->getOption('id'));
+        $ouuid = $input->getOption('ouuid') ? \strval($input->getOption('ouuid')) : null;
+        $rows = $this->revisionRepository->lockRevisions($contentType, $until, $by, $force, $ouuid);
 
         if (0 === $rows) {
             $io->error('no revisions locked, try force?');

--- a/src/Command/RecomputeCommand.php
+++ b/src/Command/RecomputeCommand.php
@@ -88,7 +88,7 @@ class RecomputeCommand extends EmsCommand
             ->addOption('continue', null, InputOption::VALUE_NONE, 'continue a recompute')
             ->addOption('no-align', null, InputOption::VALUE_NONE, "don't keep the revisions aligned to all already aligned environments")
             ->addOption('cron', null, InputOption::VALUE_NONE, 'optimized for automated recurring recompute calls, tries --continue, when no locks are found for user runs command without --continue')
-            ->addOption('id', null, InputOption::VALUE_OPTIONAL, 'recompute a specific id', 0)
+            ->addOption('ouuid', null, InputOption::VALUE_OPTIONAL, 'recompute a specific revision ouuid', null)
             ->addOption('deep', null, InputOption::VALUE_NONE, 'deep recompute form will be submitted and transformers triggered')
         ;
     }
@@ -123,8 +123,8 @@ class RecomputeCommand extends EmsCommand
             if (!\is_bool($cronFlag)) {
                 throw new \RuntimeException('Unexpected cron option');
             }
-            $idFlag = \intval($input->getOption('id'));
-            $this->lock($output, $contentType, $forceFlag, $cronFlag, $idFlag);
+            $ouuid = $input->getOption('ouuid') ? \strval($input->getOption('ouuid')) : null;
+            $this->lock($output, $contentType, $forceFlag, $cronFlag, $ouuid);
         }
 
         $optionDeep = \boolval($input->getOption('deep'));
@@ -225,7 +225,7 @@ class RecomputeCommand extends EmsCommand
         return 0;
     }
 
-    private function lock(OutputInterface $output, ContentType $contentType, bool $force = false, bool $ifEmpty = false, int $id = 0): int
+    private function lock(OutputInterface $output, ContentType $contentType, bool $force = false, bool $ifEmpty = false, ?string $ouuid = null): int
     {
         $application = $this->getApplication();
         if (null === $application) {
@@ -239,7 +239,7 @@ class RecomputeCommand extends EmsCommand
             '--user' => self::LOCK_BY,
             '--force' => $force,
             '--if-empty' => $ifEmpty,
-            '--id' => $id,
+            '--ouuid' => $ouuid,
         ];
 
         return $command->run(new ArrayInput($arguments), $output);

--- a/src/Repository/RevisionRepository.php
+++ b/src/Repository/RevisionRepository.php
@@ -596,7 +596,7 @@ class RevisionRepository extends EntityRepository
         }
     }
 
-    public function lockRevisions(?ContentType $contentType, \DateTime $until, $by, $force = false, $id = 0): int
+    public function lockRevisions(?ContentType $contentType, \DateTime $until, $by, $force = false, ?string $ouuid = null): int
     {
         $qbSelect = $this->createQueryBuilder('s');
         $qbSelect
@@ -626,11 +626,9 @@ class RevisionRepository extends EntityRepository
             $qbUpdate->setParameter('now', new \DateTime());
         }
 
-        if (\is_int($id) && $id > 0) {
-            $qbSelect->andWhere(
-                $qbSelect->expr()->eq('s.ouuid', ':content_id')
-            );
-            $qbUpdate->setParameter('content_id', $id);
+        if (null !== $ouuid) {
+            $qbSelect->andWhere($qbSelect->expr()->eq('s.ouuid', ':ouuid'));
+            $qbUpdate->setParameter('ouuid', $ouuid);
         }
 
         $qbUpdate->andWhere($qbUpdate->expr()->in('r.id', $qbSelect->getDQL()));
@@ -640,7 +638,7 @@ class RevisionRepository extends EntityRepository
 
     public function lockAllRevisions(\DateTime $until, string $by): int
     {
-        return $this->lockRevisions(null, $until, $by, true, false);
+        return $this->lockRevisions(null, $until, $by, true);
     }
 
     public function unlockRevisions(?ContentType $contentType, string $by): int

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -2138,7 +2138,7 @@ class DataService
     public function lockRevisions(ContentType $contentType, \DateTime $until, string $by): int
     {
         try {
-            return $this->revRepository->lockRevisions($contentType, $until, $by, true, false);
+            return $this->revRepository->lockRevisions($contentType, $until, $by, true);
         } catch (LockedException $e) {
             $this->logger->error('service.data.lock_revisions_error', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The id is in fact the revision ouuid, renamed id to ouuid.
It is not a int but a string value.

BC option --id becomes --ouuid for ems:contenttype:recompute page --ouuid=cb874acb1d18db6c31cd8c1831bb4991fef15e3c