### PR TITLE
fix: treat notifications update fieldType

### DIFF
--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -517,6 +517,8 @@ class NotificationService
             EmsFields::LOG_ENVIRONMENT_FIELD => $notification->getEnvironment()->getName(),
             'status' => $notification->getStatus(),
         ]);
+
+        $em->clear(); //bulk treat issue
     }
 
     public function accept(Notification $notification, TreatNotifications $treatNotifications)


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

On treating bulk notifications doctrine was clearing the parent field type 'source' by removing the contentType.

Not the best fix, but clearing the em after 1 treatment fixes the problem for now.