### PR TITLE
fix: _type to _source._contenttype in templates

### DIFF
--- a/src/Resources/views/data/view-data.html.twig
+++ b/src/Resources/views/data/view-data.html.twig
@@ -1,9 +1,9 @@
 {% extends '@EMSCore/base.html.twig' %}{% trans_default_domain 'EMSCoreBundle' %}
 
-{% block title %}Recursive view of the {{ object._type }} : {{ object._id }}{% endblock %}
+{% block title %}Recursive view of the {{ object._source._contenttype }} : {{ object._id }}{% endblock %}
 {% block pagetitle %}
     <i class="{% if contentType and contentType.icon %}{{ contentType.icon }} {% else %} fa fa-question {% endif %} "></i>
-    {{ object._type|humanize }} :
+    {{ object._source._contenttype|humanize }} :
 
     {% if contentType and (contentType.labelField) and (attribute(attribute(object, '_source'), contentType.labelField)  is defined ) %}
         {{ attribute(attribute(object, '_source'), contentType.labelField) }}

--- a/src/Resources/views/view/custom/gallery_view.html.twig
+++ b/src/Resources/views/view/custom/gallery_view.html.twig
@@ -47,7 +47,7 @@
                               	class="img-responsive center-block"
                               >
             				<div class="carousel-caption">
-                              	<div class="btn-group text-center">{{ (item._type~':'~item._id)|data_link|raw }}</div>
+                              	<div class="btn-group text-center">{{ (item._source._contenttype~':'~item._id)|data_link|raw }}</div>
             				</div>
                             </div>
                         {% endfor %}

--- a/src/Resources/views/view/custom/hierarchical_view.html.twig
+++ b/src/Resources/views/view/custom/hierarchical_view.html.twig
@@ -10,7 +10,7 @@
                 <div class="box-header with-border">
                     <h2 class="box-title">
                         {{ 'Reorganise: '|trans }}
-                        {{ (parent._type~':'~parent ._id)|data_link }}
+                        {{ (parent._source._contenttype~':'~parent._id)|data_link }}
                     </h2>
                 </div>
                 {{ form_start(form) }}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   ||	
|BC breaks?     ||	
|Deprecations?  ||	
|Fixed tickets  ||	

_type no longer exists in ES7, but was still used in our templates