### PR TITLE
fix: remove maennchen\ZipStream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
 		"dompdf/dompdf": "^0.8",
 		"elasticms/client-helper-bundle": "^3.5",
 		"guzzlehttp/guzzle" : "^6.3",
-		"maennchen/zipstream-php" : "^0.5",
 		"psr/simple-cache": "^1.0",
 		"sensio/framework-extra-bundle": "^5.4",
 		"sensiolabs/ansi-to-html" : "^1.1",


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

We are not using this namespace in the core code.
It is a very old requirement introduced on 12/27/2016

CommonBundle now has a requirement on  "phpoffice/phpspreadsheet": "^1.16" which needs "maennchen/zipstream-php": "^2.1". 