### PR TITLE
fix: choices empty data

### DIFF
--- a/src/Form/DataField/ChoiceFieldType.php
+++ b/src/Form/DataField/ChoiceFieldType.php
@@ -101,7 +101,7 @@ class ChoiceFieldType extends DataFieldType
                 'required' => false,
                 'disabled' => $this->isDisabled($options),
                 'choices' => $choices,
-                'empty_data' => null,
+                'empty_data' => $options['multiple'] ? [] : null,
                 'multiple' => $options['multiple'],
                 'expanded' => $options['expanded'],
                 'choice_attr' => [$this, 'choiceAttr'],

--- a/src/Form/DataField/JsonMenuLinkFieldType.php
+++ b/src/Form/DataField/JsonMenuLinkFieldType.php
@@ -106,7 +106,7 @@ class JsonMenuLinkFieldType extends DataFieldType
                 'required' => false,
                 'disabled' => $this->isDisabled($options),
                 'choices' => $choices,
-                'empty_data' => null,
+                'empty_data' => [],
                 'multiple' => true,
                 'expanded' => $options['expanded'],
         ]);

--- a/src/Form/DataField/JsonMenuNestedLinkFieldType.php
+++ b/src/Form/DataField/JsonMenuNestedLinkFieldType.php
@@ -125,7 +125,7 @@ class JsonMenuNestedLinkFieldType extends DataFieldType
             'required' => false,
             'disabled' => $this->isDisabled($options),
             'choices' => $choices,
-            'empty_data' => null,
+            'empty_data' => $options['multiple'] ? [] : null,
             'multiple' => $options['multiple'],
             'expanded' => $options['expanded'],
         ]);

--- a/src/Form/DataField/SelectFieldType.php
+++ b/src/Form/DataField/SelectFieldType.php
@@ -56,7 +56,7 @@ class SelectFieldType extends DataFieldType
                 'required' => false,
                 'disabled' => $this->isDisabled($options),
                 'choices' => $choices,
-                'empty_data' => null,
+                'empty_data' => $options['multiple'] ? [] : null,
                 'multiple' => $options['multiple'],
         ]);
     }

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -889,10 +889,10 @@ class DataService
             $fieldForm = $formError->getOrigin();
             $dataField = null;
             while (null !== $fieldForm && !$fieldForm->getNormData() instanceof DataField) {
-                $fieldForm = $fieldForm->getOrigin()->getParent();
+                $fieldForm = $fieldForm->getParent();
             }
 
-            if (!$fieldForm->getNormData() instanceof DataField) {
+            if (!$fieldForm instanceof FormInterface || !$fieldForm->getNormData() instanceof DataField) {
                 continue;
             }
             /** @var DataField $dataField */


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

In symfony forms 4.4.20 multiple choices only allow arrays

https://github.com/symfony/form/commit/c03e236d623624d1ee1e71cd4e3a70023f5d18ee