### PR TITLE
fix: global search twig error

### DIFF
--- a/src/Resources/views/elasticsearch/search.html.twig
+++ b/src/Resources/views/elasticsearch/search.html.twig
@@ -269,9 +269,9 @@
 	{% include '@EMSCore/app/menu.html.twig' with {
 		'item':  'data-index-' ~ attribute(types, form.contentTypes.vars.value.0).id
 	}%}
-{% elseif response.getAggregation('types').buckets|length == 1 %}
+{% elseif response.getAggregation('types').keys|length == 1 %}
 	{% include '@EMSCore/app/menu.html.twig' with {
-		'item':  'data-index-' ~ attribute(types, response.getAggregation('types').buckets.0.key).id
+		'item':  'data-index-' ~ attribute(types, response.getAggregation('types').keys.0).id
 	}%}
 {% endif %}
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Neither the property "0" nor one of the methods "0()",
"get0()"/"is0()"/"has0()" or "__call()" exist and have public access in
class "Generator".