### PR TITLE
fix: TranslatorInterface contract instead of DataCollectorTranslator …

### DIFF
--- a/src/Command/DocumentCommand.php
+++ b/src/Command/DocumentCommand.php
@@ -39,12 +39,14 @@ class DocumentCommand extends Command
     const ARGUMENT_CONTENTTYPE = 'contentTypeName';
     /** @var string */
     const ARGUMENT_ARCHIVE = 'archive';
+    private int $defaultBulkSize;
 
-    public function __construct(ContentTypeService $contentTypeService, DocumentService $documentService, DataService $dataService)
+    public function __construct(ContentTypeService $contentTypeService, DocumentService $documentService, DataService $dataService, int $defaultBulkSize)
     {
         $this->contentTypeService = $contentTypeService;
         $this->documentService = $documentService;
         $this->dataService = $dataService;
+        $this->defaultBulkSize = $defaultBulkSize;
         parent::__construct();
     }
 
@@ -67,7 +69,7 @@ class DocumentCommand extends Command
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Size of the elasticsearch bulk request',
-                500
+                $this->defaultBulkSize
             )
             ->addOption(
                 'raw',

--- a/src/Command/RebuildCommand.php
+++ b/src/Command/RebuildCommand.php
@@ -38,8 +38,10 @@ class RebuildCommand extends EmsCommand
     private $mapping;
     /** @var AliasService */
     private $aliasService;
+    /** @var int */
+    private $defaultBulkSize;
 
-    public function __construct(Registry $doctrine, LoggerInterface $logger, ContentTypeService $contentTypeService, EnvironmentService $environmentService, ReindexCommand $reindexCommand, ElasticaService $elasticaService, Mapping $mapping, AliasService $aliasService, string $instanceId)
+    public function __construct(Registry $doctrine, LoggerInterface $logger, ContentTypeService $contentTypeService, EnvironmentService $environmentService, ReindexCommand $reindexCommand, ElasticaService $elasticaService, Mapping $mapping, AliasService $aliasService, string $instanceId, int $defaultBulkSize)
     {
         $this->doctrine = $doctrine;
         $this->contentTypeService = $contentTypeService;
@@ -50,6 +52,7 @@ class RebuildCommand extends EmsCommand
         $this->logger = $logger;
         $this->mapping = $mapping;
         $this->aliasService = $aliasService;
+        $this->defaultBulkSize = $defaultBulkSize;
         parent::__construct();
     }
 
@@ -86,7 +89,7 @@ class RebuildCommand extends EmsCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Number of item that will be indexed together during the same elasticsearch operation',
-                500
+                $this->defaultBulkSize
             )
         ;
     }

--- a/src/Command/ReindexCommand.php
+++ b/src/Command/ReindexCommand.php
@@ -44,8 +44,10 @@ class ReindexCommand extends EmsCommand
     private $error;
     /** @var Bulker */
     private $bulker;
+    /** @var int */
+    private $defaultBulkSize;
 
-    public function __construct(Registry $doctrine, LoggerInterface $logger, Mapping $mapping, ContainerInterface $container, string $instanceId, DataService $dataService, Bulker $bulker)
+    public function __construct(Registry $doctrine, LoggerInterface $logger, Mapping $mapping, ContainerInterface $container, string $instanceId, DataService $dataService, Bulker $bulker, int $defaultBulkSize)
     {
         $this->doctrine = $doctrine;
         $this->logger = $logger;
@@ -54,6 +56,7 @@ class ReindexCommand extends EmsCommand
         $this->instanceId = $instanceId;
         $this->dataService = $dataService;
         $this->bulker = $bulker;
+        $this->defaultBulkSize = $defaultBulkSize;
         parent::__construct();
 
         $this->count = 0;
@@ -93,7 +96,7 @@ class ReindexCommand extends EmsCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Number of item that will be indexed together during the same elasticsearch operation',
-                1000
+                $this->defaultBulkSize
             );
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
     const TIKA_SERVER = null;
     const SAVE_ASSETS_IN_DB = false;
     const LOG_LEVEL = 'info';
+    const DEFAULT_BULK_SIZE = 500;
 
     /**
      * {@inheritdoc}
@@ -89,6 +90,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('template_options')->defaultValue([])->prototype('variable')->end()->end()
             ->scalarNode('health_check_allow_origin')->defaultValue(null)->end()
             ->scalarNode('tika_download_url')->defaultValue(null)->end()
+            ->scalarNode('default_bulk_size')->defaultValue(self::DEFAULT_BULK_SIZE)->end()
             ->arrayNode('ldap')
             ->children()
             ->scalarNode('base_dn')->end()

--- a/src/DependencyInjection/EMSCoreExtension.php
+++ b/src/DependencyInjection/EMSCoreExtension.php
@@ -68,6 +68,7 @@ class EMSCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('ems_core.tika_download_url', $config['tika_download_url']);
         $container->setParameter('ems_core.log_by_pass', $config['log_by_pass']);
         $container->setParameter('ems_core.log_level', $config['log_level']);
+        $container->setParameter('ems_core.default_bulk_size', $config['default_bulk_size']);
 
         $this->loadLdap($container, $yamlLoader, $config['ldap'] ?? []);
     }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -535,7 +535,7 @@ services:
             -  { name: console.command }
     ems.make.document:
         class: EMS\CoreBundle\Command\DocumentCommand
-        arguments: ['@ems.service.contenttype', '@ems.service.document', '@ems.service.data']
+        arguments: ['@ems.service.contenttype', '@ems.service.document', '@ems.service.data', '%ems_core.default_bulk_size%']
         tags:
             -  { name: console.command }
     ems.contenttype.export:
@@ -545,7 +545,7 @@ services:
             -  { name: console.command }
     ems.environment.rebuild:
         class: EMS\CoreBundle\Command\RebuildCommand
-        arguments: ['@doctrine', '@logger', '@ems.service.contenttype', '@ems.service.environment', '@ems.environment.reindex', '@ems_common.service.elastica', '@ems.service.mapping', '@ems.service.alias', '%ems_core.instance_id%']
+        arguments: ['@doctrine', '@logger', '@ems.service.contenttype', '@ems.service.environment', '@ems.environment.reindex', '@ems_common.service.elastica', '@ems.service.mapping', '@ems.service.alias', '%ems_core.instance_id%', '%ems_core.default_bulk_size%']
         tags:
             -  { name: console.command }
     ems.delete.orphans:
@@ -580,7 +580,7 @@ services:
             -  { name: console.command }
     ems.environment.reindex:
         class: EMS\CoreBundle\Command\ReindexCommand
-        arguments: ['@doctrine', '@logger', '@ems.service.mapping', '@service_container', '%ems_core.instance_id%', '@ems.service.data', '@ems.elasticsearch.bulker']
+        arguments: ['@doctrine', '@logger', '@ems.service.mapping', '@service_container', '%ems_core.instance_id%', '@ems.service.data', '@ems.elasticsearch.bulker', '%ems_core.default_bulk_size%']
         tags:
             -  { name: console.command }
     ems.contenttype.delete:

--- a/src/Service/Form/Submission/FormSubmissionService.php
+++ b/src/Service/Form/Submission/FormSubmissionService.php
@@ -12,7 +12,7 @@ use EMS\CoreBundle\Service\TemplateService;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Translation\DataCollectorTranslator as Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use ZipStream\ZipStream;
 
@@ -27,14 +27,14 @@ final class FormSubmissionService implements EntityServiceInterface
     /** @var Session<mixed> */
     private Session $session;
 
-    private Translator $translator;
+    private TranslatorInterface $translator;
 
     /**
      * FormSubmissionService constructor.
      *
      * @param Session<mixed> $session
      */
-    public function __construct(FormSubmissionRepository $formSubmissionRepository, TemplateService $templateService, Environment $twig, Session $session, Translator $translator)
+    public function __construct(FormSubmissionRepository $formSubmissionRepository, TemplateService $templateService, Environment $twig, Session $session, TranslatorInterface $translator)
     {
         $this->formSubmissionRepository = $formSubmissionRepository;
         $this->templateService = $templateService;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Faced an issue with the commands. The empty command was throwing an exception as Symfony was not able to instaciate the FormSubmissionService.  Indeed the FormSubmissionService was referring a DataCollectorTranslator (which is the debug Translator). I replaced it by the Interface contract.