### PR TITLE
Feat/check alias

### DIFF
--- a/src/Command/Check/AliasesCheckCommand.php
+++ b/src/Command/Check/AliasesCheckCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\Check;
 
 use EMS\CoreBundle\Service\AliasService;
-use EMS\CoreBundle\Service\ContentTypeService;
+use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\JobService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,14 +15,14 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class AliasesCheckCommand extends Command
 {
     public const COMMAND = 'ems:check:aliases';
-    private ContentTypeService $contentTypeService;
+    private EnvironmentService $environmentService;
     private AliasService $aliasService;
     private JobService $jobService;
     private SymfonyStyle $io;
 
-    public function __construct(ContentTypeService $contentTypeService, AliasService $aliasService, JobService $jobService)
+    public function __construct(EnvironmentService $environmentService, AliasService $aliasService, JobService $jobService)
     {
-        $this->contentTypeService = $contentTypeService;
+        $this->environmentService = $environmentService;
         $this->aliasService = $aliasService;
         $this->jobService = $jobService;
         parent::__construct();
@@ -44,6 +44,15 @@ final class AliasesCheckCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Start checking environment\'s aliase');
+        foreach ($this->environmentService->getEnvironments() as $environment) {
+            if (!$environment->getManaged()) {
+                continue;
+            }
+            $this->io->writeln(\sprintf('Verifying environment %s', $environment->getName()));
+            if (!$this->aliasService->hasAlias($environment->getAlias())) {
+                $this->io->warning(\sprintf('The %s\' environment is missing', $environment->getName()));
+            }
+        }
 
         return 0;
     }

--- a/src/Command/Check/AliasesCheckCommand.php
+++ b/src/Command/Check/AliasesCheckCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Command\Check;
+
+use EMS\CoreBundle\Service\AliasService;
+use EMS\CoreBundle\Service\ContentTypeService;
+use EMS\CoreBundle\Service\JobService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class AliasesCheckCommand extends Command
+{
+    public const COMMAND = 'ems:check:aliases';
+    private ContentTypeService $contentTypeService;
+    private AliasService $aliasService;
+    private JobService $jobService;
+    private SymfonyStyle $io;
+
+    public function __construct(ContentTypeService $contentTypeService, AliasService $aliasService, JobService $jobService)
+    {
+        $this->contentTypeService = $contentTypeService;
+        $this->aliasService = $aliasService;
+        $this->jobService = $jobService;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName(self::COMMAND)
+            ->setDescription('Checks that all managed environments have their corresponding alias and index present in the cluster. If not and if they are no pending job a rebuild job is queued.');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->section('Start checking environment\'s aliase');
+
+        return 0;
+    }
+}

--- a/src/Command/Check/AliasesCheckCommand.php
+++ b/src/Command/Check/AliasesCheckCommand.php
@@ -48,10 +48,18 @@ final class AliasesCheckCommand extends Command
             if (!$environment->getManaged()) {
                 continue;
             }
-            $this->io->writeln(\sprintf('Verifying environment %s', $environment->getName()));
-            if (!$this->aliasService->hasAlias($environment->getAlias())) {
-                $this->io->warning(\sprintf('The %s\' environment is missing', $environment->getName()));
+            if ($this->aliasService->hasAlias($environment->getAlias())) {
+                $this->io->writeln(\sprintf('Environment\'s alias %s is present', $environment->getName()));
+                continue;
             }
+            $this->io->warning(\sprintf('The %s\' environment is missing', $environment->getName()));
+
+            if ($this->jobService->countPending() > 0) {
+                $this->io->warning('The job\'s queue is not empty');
+                break;
+            }
+
+            break;
         }
 
         return 0;

--- a/src/Command/Check/AliasesCheckCommand.php
+++ b/src/Command/Check/AliasesCheckCommand.php
@@ -50,11 +50,11 @@ final class AliasesCheckCommand extends Command
             if (!$environment->getManaged()) {
                 continue;
             }
-            if ($this->aliasService->hasAlias($environment->getAlias())) {
+            if ($environment->hasAlias() && $this->aliasService->hasAliasInCluster($environment->getAlias())) {
                 $this->io->writeln(\sprintf('Environment\'s alias %s is present', $environment->getName()));
                 continue;
             }
-            $this->io->warning(\sprintf('The %s\' environment is missing', $environment->getName()));
+            $this->io->warning(\sprintf('The %s environment\'s alias is missing', $environment->getName()));
 
             if ($this->jobService->countPending() > 0) {
                 $this->io->warning('The job\'s queue is not empty');

--- a/src/Command/Check/AliasesCheckCommand.php
+++ b/src/Command/Check/AliasesCheckCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Command\Check;
 
+use EMS\CoreBundle\Command\RebuildCommand;
+use EMS\CoreBundle\Entity\User;
 use EMS\CoreBundle\Service\AliasService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\JobService;
@@ -59,6 +61,14 @@ final class AliasesCheckCommand extends Command
                 break;
             }
 
+            $fakeUser = new User();
+            $fakeUser->setUsername(self::COMMAND);
+            $command = \join(' ', [
+                RebuildCommand::COMMAND,
+                $environment->getName(),
+            ]);
+            $this->jobService->createCommand($fakeUser, $command);
+            $this->io->writeln(\sprintf('A command `%s` has been initialized', $command));
             break;
         }
 

--- a/src/Command/Check/AliasesCheckCommand.php
+++ b/src/Command/Check/AliasesCheckCommand.php
@@ -40,7 +40,6 @@ final class AliasesCheckCommand extends Command
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new SymfonyStyle($input, $output);
-        $this->io = new SymfonyStyle($input, $output);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -62,7 +62,12 @@ class JobCommand extends Command
             \sprintf('Created: %s', $job->getCreated()->format($this->dateFormat)),
         ]);
         $start = new \DateTime();
-        $this->jobService->run($job);
+        try {
+            $this->jobService->run($job);
+        } catch (\Throwable $e) {
+            $this->jobService->finish($job);
+            throw $e;
+        }
         $interval = \date_diff($start, new \DateTime());
 
         $this->io->success(\sprintf('Job completed with the return status "%s" in %s', $job->getStatus(), $interval->format('%a days, %h hours, %i minutes and %s seconds')));

--- a/src/Command/RebuildCommand.php
+++ b/src/Command/RebuildCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RebuildCommand extends EmsCommand
 {
+    public const COMMAND = 'ems:environment:rebuild';
     /** @var Registry */
     private $doctrine;
     /** @var ContentTypeService */
@@ -56,7 +57,7 @@ class RebuildCommand extends EmsCommand
     protected function configure(): void
     {
         $this
-            ->setName('ems:environment:rebuild')
+            ->setName(self::COMMAND)
             ->setDescription('Rebuild an environment in a brand new index')
             ->addArgument(
                 'name',

--- a/src/Entity/Environment.php
+++ b/src/Entity/Environment.php
@@ -473,6 +473,11 @@ class Environment extends JsonDeserializer implements \JsonSerializable
         return $this->alias;
     }
 
+    public function hasAlias(): bool
+    {
+        return null !== $this->alias;
+    }
+
     public function getNewIndexName(): string
     {
         return \sprintf('%s_%s', $this->getAlias(), (new \DateTimeImmutable())->format('Ymd_His'));

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CoreBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -6,14 +6,22 @@ use Doctrine\ORM\EntityRepository;
 
 class JobRepository extends EntityRepository
 {
-    /**
-     * @return string
-     */
-    public function countJobs()
+    public function countJobs(): int
     {
-        return $this->createQueryBuilder('a')
+        return \intval($this->createQueryBuilder('a')
             ->select('COUNT(a)')
             ->getQuery()
-            ->getSingleScalarResult();
+            ->getSingleScalarResult());
+    }
+
+    public function countPendingJobs(): int
+    {
+        $qb = $this->createQueryBuilder('a')->select('COUNT(a)');
+        $qb->where($qb->expr()->eq('a.done', ':false'));
+        $qb->setParameters([
+            ':false' => false,
+        ]);
+
+        return \intval($qb->getQuery()->getSingleScalarResult());
     }
 }

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20210320212242.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20210320212242.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Application\Migrations;
 
@@ -7,14 +9,14 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20210320212242 extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('UPDATE job SET done = TRUE WHERE done IS FALSE AND started is TRUE');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
     }
 }

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20210320212242.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20210320212242.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210320212242 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('UPDATE job SET done = TRUE WHERE done IS FALSE AND started is TRUE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+    }
+}

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -35,7 +35,7 @@
             <tag name="console.command"/>
         </service>
         <service id="ems.command.check.aliases" class="EMS\CoreBundle\Command\Check\AliasesCheckCommand">
-            <argument type="service" id="ems.service.contenttype"/>
+            <argument type="service" id="ems.service.environment"/>
             <argument type="service" id="ems.service.alias"/>
             <argument type="service" id="ems.service.job"/>
             <tag name="console.command"/>

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -34,5 +34,11 @@
             <argument>%ems_core.notification_pending_timeout%</argument>
             <tag name="console.command"/>
         </service>
+        <service id="ems.command.check.aliases" class="EMS\CoreBundle\Command\Check\AliasesCheckCommand">
+            <argument type="service" id="ems.service.contenttype"/>
+            <argument type="service" id="ems.service.alias"/>
+            <argument type="service" id="ems.service.job"/>
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/src/Service/AliasService.php
+++ b/src/Service/AliasService.php
@@ -80,7 +80,20 @@ class AliasService
 
     public function hasAlias(string $name): bool
     {
-        return isset($this->aliases[$name]);
+        if ($this->isBuild) {
+            return isset($this->aliases[$name]);
+        }
+
+        $endpoint = new Get();
+        $endpoint->setName($name);
+        try {
+            $this->elasticaClient->requestEndpoint($endpoint)->getData();
+
+            return true;
+        } catch (\Throwable $e) {
+        }
+
+        return false;
     }
 
     /**

--- a/src/Service/AliasService.php
+++ b/src/Service/AliasService.php
@@ -80,10 +80,11 @@ class AliasService
 
     public function hasAlias(string $name): bool
     {
-        if ($this->isBuild) {
-            return isset($this->aliases[$name]);
-        }
+        return isset($this->aliases[$name]);
+    }
 
+    public function hasAliasInCluster(string $name): bool
+    {
         $endpoint = new Get();
         $endpoint->setName($name);
         try {

--- a/src/Service/JobService.php
+++ b/src/Service/JobService.php
@@ -77,7 +77,12 @@ class JobService
 
     public function count(): int
     {
-        return \intval($this->repository->countJobs());
+        return $this->repository->countJobs();
+    }
+
+    public function countPending(): int
+    {
+        return $this->repository->countPendingJobs();
     }
 
     public function createCommand(UserInterface $user, ?string $command): Job

--- a/src/Service/JobService.php
+++ b/src/Service/JobService.php
@@ -120,7 +120,7 @@ class JobService
             $output->writeln('Exception:'.$e->getMessage());
         }
 
-        $this->finish($job, $output);
+        $this->finish($job);
     }
 
     /**
@@ -145,7 +145,7 @@ class JobService
         return $output;
     }
 
-    public function finish(Job $job, JobOutput $output): void
+    public function finish(Job $job): void
     {
         $job->setDone(true);
         $job->setProgress(100);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

A command to check if all managed environments have an alias. If not a rebuild job initialized. This command will be integrated in the docker image in order to proactively rebuild lost aliases/indexes.