### PR TITLE
fix: default value fo UploadedAsset hidden field

### DIFF
--- a/src/Entity/UploadedAsset.php
+++ b/src/Entity/UploadedAsset.php
@@ -104,7 +104,7 @@ class UploadedAsset implements EntityInterface
     /**
      * @ORM\Column(name="hidden", type="boolean", options={"default" : 0})
      */
-    private bool $hidden;
+    private bool $hidden = false;
 
     /**
      * @ORM\Column(name="head_last", type="datetime", nullable=true)


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   ||	
|BC breaks?     ||	
|Deprecations?  ||	
|Fixed tickets  ||	

Default value for UploadedAsset hidden field