### PR TITLE
feat: datatable advance options

### DIFF
--- a/doc/twig/datatable.md
+++ b/doc/twig/datatable.md
@@ -84,4 +84,32 @@ It's the elasticsearch query (array or string) used when nothing is defined in t
 {
 }
 ```
+## frontendOptions
 
+It allows you to override every [datatables.net options](https://datatables.net/reference/option/) that you want. It's very flexible but also a bit dangerous if you start overriding the `ajax` or `serverSide` parameters. Default value `{}`
+
+I.e.:
+```twig
+{{ emsco_datatable(['ldap'],['ldap_user'], {
+    "frontendOptions": {
+        "pageLength": 100
+    },
+    "query": {
+        "multi_match": {
+          "query": "%query%",
+          "operator": "and",
+          "type": "bool_prefix",
+          "fields": [
+            "live_search",
+            "live_search._2gram",
+            "live_search._3gram"
+          ]
+        }
+      },
+    "columns": [{
+        "label": "Name",
+        "template": "{{ data.source.name|default('') }}",
+        "orderField": "name.keyword"
+    }]
+}) }}
+```

--- a/doc/twig/datatable.md
+++ b/doc/twig/datatable.md
@@ -26,6 +26,8 @@ The third parameter is an options array:
         - `data`: EMS\CommonBundle\Elasticsearch\Document\DocumentInterface
         - `column`: EMS\CoreBundle\Form\Data\TemplateTableColumn
     - `orderField`: this value (string) will be used in the elasticsearch query, when the table is sorted by this column, in order to sort the result set. If not defined, or set to null, this column won't be sortable. If not defined the column wont't be sortable.
+    - `cellType`: The HTML tag for the column's items. `td` or `th`. Default value `td`
+    - `cellClass`: The class attribute for the column's items. The default value is an empty string.  
    
 ## Optional options
 
@@ -82,3 +84,4 @@ It's the elasticsearch query (array or string) used when nothing is defined in t
 {
 }
 ```
+

--- a/src/Form/Data/ElasticaTable.php
+++ b/src/Form/Data/ElasticaTable.php
@@ -14,6 +14,7 @@ class ElasticaTable extends TableAbstract
     private const COLUMNS = 'columns';
     private const QUERY = 'query';
     private const EMPTY_QUERY = 'empty_query';
+    private const FRONTEND_OPTIONS = 'frontendOptions';
     private ElasticaService $elasticaService;
     /** @var string[] */
     private array $aliases;
@@ -50,6 +51,7 @@ class ElasticaTable extends TableAbstract
         foreach ($options[self::COLUMNS] as $column) {
             $datatable->addColumnDefinition(new TemplateTableColumn($column));
         }
+        $datatable->setExtraFrontendOption($options[self::FRONTEND_OPTIONS]);
 
         return $datatable;
     }
@@ -122,7 +124,7 @@ class ElasticaTable extends TableAbstract
     /**
      * @param array<string, mixed> $options
      *
-     * @return array{columns: array, query: string, empty_query: string}
+     * @return array{columns: array, query: string, empty_query: string, frontendOptions: array}
      */
     private static function resolveOptions(array $options)
     {
@@ -136,6 +138,7 @@ class ElasticaTable extends TableAbstract
                         'query' => '%query%',
                     ],
                 ],
+                self::FRONTEND_OPTIONS => [],
             ])
             ->setAllowedTypes(self::COLUMNS, ['array'])
             ->setAllowedTypes(self::QUERY, ['array', 'string'])
@@ -161,7 +164,7 @@ class ElasticaTable extends TableAbstract
                 return $value;
             })
         ;
-        /** @var array{columns: array, query: string, empty_query: string} $resolvedParameter */
+        /** @var array{columns: array, query: string, empty_query: string, frontendOptions: array} $resolvedParameter */
         $resolvedParameter = $resolver->resolve($options);
 
         return $resolvedParameter;

--- a/src/Form/Data/TableAbstract.php
+++ b/src/Form/Data/TableAbstract.php
@@ -31,6 +31,8 @@ abstract class TableAbstract implements TableInterface
     private int $from;
     private string $searchValue = '';
     private ?string $ajaxUrl = null;
+    /** @var array<mixed> */
+    private array $extraFrontendOption = [];
 
     public function __construct(?string $ajaxUrl, int $from, int $to)
     {
@@ -188,6 +190,16 @@ abstract class TableAbstract implements TableInterface
     }
 
     /**
+     * @param array<mixed> $extraFrontendOption
+     */
+    public function setExtraFrontendOption(array $extraFrontendOption): TableAbstract
+    {
+        $this->extraFrontendOption = $extraFrontendOption;
+
+        return $this;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function getFrontendOptions(): array
@@ -232,6 +244,8 @@ abstract class TableAbstract implements TableInterface
             $columnOptions[] = \array_merge($column->getFrontendOptions(), ['targets' => $columnTarget++]);
         }
         $options['columnDefs'] = $columnOptions;
+
+        $options = \array_merge($options, $this->extraFrontendOption);
 
         return $options;
     }

--- a/src/Form/Data/TableAbstract.php
+++ b/src/Form/Data/TableAbstract.php
@@ -220,6 +220,19 @@ abstract class TableAbstract implements TableInterface
             ]);
         }
 
+        $columnOptions = [];
+        $columnTarget = 0;
+        if ($this->supportsTableActions()) {
+            $columnOptions[] = [
+                'targets' => $columnTarget++,
+            ];
+        }
+
+        foreach ($this->getColumns() as $column) {
+            $columnOptions[] = \array_merge($column->getFrontendOptions(), ['targets' => $columnTarget++]);
+        }
+        $options['columnDefs'] = $columnOptions;
+
         return $options;
     }
 

--- a/src/Form/Data/TableColumn.php
+++ b/src/Form/Data/TableColumn.php
@@ -43,6 +43,14 @@ class TableColumn
     }
 
     /**
+     * @return array<mixed>
+     */
+    public function getFrontendOptions(): array
+    {
+        return [];
+    }
+
+    /**
      * @param mixed $data
      *
      * @return array<string, mixed>|null

--- a/src/Form/Data/TableColumn.php
+++ b/src/Form/Data/TableColumn.php
@@ -13,6 +13,8 @@ class TableColumn
     private ?string $routeTarget = null;
     private ?string $iconClass = null;
     private ?\Closure $itemIconCallback = null;
+    private string $cellType = 'td';
+    private string $cellClass = '';
 
     public function __construct(string $titleKey, string $attribute)
     {
@@ -47,7 +49,27 @@ class TableColumn
      */
     public function getFrontendOptions(): array
     {
-        return [];
+        return [
+            'cellType' => $this->cellType,
+            'className' => $this->cellClass,
+        ];
+    }
+
+    public function setCellType(string $cellType): TableColumn
+    {
+        if (!\in_array($cellType, ['td', 'tr'])) {
+            throw new \RuntimeException(\sprintf('Unexpected cellType option %s, only td and tr are accepted', $cellType));
+        }
+        $this->cellType = $cellType;
+
+        return $this;
+    }
+
+    public function setCellClass(string $cellClass): TableColumn
+    {
+        $this->cellClass = $cellClass;
+
+        return $this;
     }
 
     /**

--- a/src/Form/Data/TemplateTableColumn.php
+++ b/src/Form/Data/TemplateTableColumn.php
@@ -11,8 +11,8 @@ final class TemplateTableColumn extends TableColumn
     private const LABEL = 'label';
     private const TEMPLATE = 'template';
     private const ORDER_FIELD = 'orderField';
-    const CELL_TYPE = 'cellType';
-    const CELL_CLASS = 'cellClass';
+    private const CELL_TYPE = 'cellType';
+    private const CELL_CLASS = 'cellClass';
     private bool $orderable;
     private string $template;
 

--- a/src/Form/Data/TemplateTableColumn.php
+++ b/src/Form/Data/TemplateTableColumn.php
@@ -11,6 +11,8 @@ final class TemplateTableColumn extends TableColumn
     private const LABEL = 'label';
     private const TEMPLATE = 'template';
     private const ORDER_FIELD = 'orderField';
+    const CELL_TYPE = 'cellType';
+    const CELL_CLASS = 'cellClass';
     private bool $orderable;
     private string $template;
 
@@ -23,6 +25,8 @@ final class TemplateTableColumn extends TableColumn
         $this->orderable = null !== $options[self::ORDER_FIELD];
         $this->template = $options[self::TEMPLATE];
         parent::__construct($options[self::LABEL], $options[self::ORDER_FIELD] ?? 'not orderable');
+        $this->setCellClass($options[self::CELL_CLASS]);
+        $this->setCellType($options[self::CELL_TYPE]);
     }
 
     public function getOrderable(): bool
@@ -43,7 +47,7 @@ final class TemplateTableColumn extends TableColumn
     /**
      * @param array<string, mixed> $options
      *
-     * @return array{label: string, template: string, orderField: string|null}
+     * @return array{label: string, template: string, orderField: string|null, cellType: string, cellClass: string}
      */
     private static function resolveOptions(array $options)
     {
@@ -53,12 +57,16 @@ final class TemplateTableColumn extends TableColumn
                 self::LABEL => 'Label',
                 self::TEMPLATE => '',
                 self::ORDER_FIELD => null,
+                self::CELL_TYPE => 'td',
+                self::CELL_CLASS => '',
             ])
             ->setAllowedTypes(self::LABEL, ['string'])
             ->setAllowedTypes(self::TEMPLATE, ['string'])
             ->setAllowedTypes(self::ORDER_FIELD, ['string', 'null'])
+            ->setAllowedTypes(self::CELL_TYPE, ['string'])
+            ->setAllowedTypes(self::CELL_CLASS, ['string'])
         ;
-        /** @var array{label: string, template: string, orderField: string|null} $resolvedParameter */
+        /** @var array{label: string, template: string, orderField: string|null, cellType: string, cellClass: string} $resolvedParameter */
         $resolvedParameter = $resolver->resolve($options);
 
         return $resolvedParameter;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Allow to customize the tag and the class attribute of a datatable cell