### PR TITLE
fix: non nested sub field

### DIFF
--- a/src/Service/SearchService.php
+++ b/src/Service/SearchService.php
@@ -179,7 +179,7 @@ class SearchService
 
             $fieldMapping = $mapping[$field];
 
-            if ('nested' == $fieldMapping['type']) {
+            if ('nested' === ($fieldMapping['type'] ?? null)) {
                 $nestedPath[] = $field;
                 $mapping = $fieldMapping['properties'] ?? []; //go to nested properties
             } elseif (isset($fieldMapping['fields'])) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

a . in a field name also be used to artificially prefix a field, not always a subfield. In case of external defined mapping. 