### PR TITLE
fix: api upload assets multiple records

### DIFF
--- a/src/Service/FileService.php
+++ b/src/Service/FileService.php
@@ -222,9 +222,12 @@ class FileService implements EntityServiceInterface
         /** @var UploadedAsset|null $uploadedAsset */
         $uploadedAsset = $repository->findOneBy([
             'sha1' => $hash,
-            'available' => false,
             'user' => $user,
         ]);
+
+        if ($uploadedAsset && $uploadedAsset->getAvailable()) {
+            return $uploadedAsset;
+        }
 
         if (null === $uploadedAsset) {
             $uploadedAsset = new UploadedAsset($this->storageManager);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

We are now showing the uploaded assets in EMS. If a user already uploaded a asset don't create a new record.