### PR TITLE
fix: emslink linkpicker (use in skeleton)

### DIFF
--- a/src/Controller/UploadedFileWysiwygController.php
+++ b/src/Controller/UploadedFileWysiwygController.php
@@ -62,7 +62,7 @@ final class UploadedFileWysiwygController extends AbstractController
         $table = new EntityTable($this->fileService, $this->generateUrl('ems_core_uploaded_file_ajax'), ['available' => false]);
         $table->addColumn('uploaded-file.index.column.name', 'name')
             ->addHtmlAttribute('data-url', function (UploadedAsset $data) {
-                return EMSLink::EMSLINK_ASSET_PREFIX.$data->getSha1();
+                return EMSLink::EMSLINK_ASSET_PREFIX.$data->getSha1().'?name='.$data->getName().'&type='.$data->getType();
             })
             ->setRoute('ems_file_download', function (UploadedAsset $data) {
                 if (!$data->getAvailable()) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Debug emslink asset in wysiwyg when use in skeleton (missing parameters type and name)