### PR TITLE
feat: try to add a channel's alias in request headers

### DIFF
--- a/src/Resources/config/routing/asset.xml
+++ b/src/Resources/config/routing/asset.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="ems_core_asset_proxy" path="/emsch_assets/{requestPath}" methods="GET">
-        <default key="_controller">EMS\ClientHelperBundle\Controller\AssetController:proxyFromRefererPattern</default>
+        <default key="_controller">EMS\ClientHelperBundle\Controller\AssetController:proxyFromInternalHeader</default>
         <requirement key="requestPath">.+</requirement>
     </route>
 

--- a/src/Service/Channel/ChannelRegistrar.php
+++ b/src/Service/Channel/ChannelRegistrar.php
@@ -20,7 +20,7 @@ final class ChannelRegistrar
     private LoggerInterface $logger;
     private IndexService $indexService;
 
-    private const EMSCO_CHANNEL_PATH_REGEX = '/^\\/channel\\/(?P<channel>([a-z\\-0-9_]+))(\\/)?/';
+    private const EMSCO_CHANNEL_PATH_REGEX = '/^(\\/index\\.php)?\\/channel\\/(?P<channel>([a-z\\-0-9_]+))(\\/)?/';
 
     public function __construct(ChannelRepository $channelRepository, EnvironmentHelperInterface $environmentHelper, LoggerInterface $logger, IndexService $indexService)
     {
@@ -90,6 +90,12 @@ final class ChannelRegistrar
 
         $referer = $request->headers->get('referer', null);
         if (!\is_string($referer)) {
+            $referer = $request->headers->get('Referer', null);
+        }
+        if (!\is_string($referer)) {
+            $referer = $request->headers->get('REFERER', null);
+        }
+        if (!\is_string($referer)) {
             return;
         }
 
@@ -115,6 +121,6 @@ final class ChannelRegistrar
             return;
         }
 
-        $request->headers->set(AssetController::REQUEST_HEADER_CHANNEL_ALIAS, $alias);
+        $request->headers->set(AssetController::REQUEST_HEADER_ENVIRONMENT_ALIAS, $alias);
     }
 }


### PR DESCRIPTION
  if:
  - the request starts by /bundles/
 - the request referer is in a channel context

|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The channel's name is not always equal to the channel's alias