### PR TITLE
fix: asset proxy for already proxied asset referer

### DIFF
--- a/src/Controller/ContentManagement/AssetController.php
+++ b/src/Controller/ContentManagement/AssetController.php
@@ -87,7 +87,7 @@ class AssetController extends AbstractController
         }
         $baseUrl = $request->getBaseUrl() ?? '';
 
-        if (\strlen($refererPath) > 0 && 0 !== \strpos($refererPath, $baseUrl)) {
+        if (\strlen($baseUrl) > 0 && 0 !== \strpos($refererPath, $baseUrl)) {
             throw new NotFoundHttpException(\sprintf('File %s not found', $requestPath));
         }
 

--- a/src/Controller/ContentManagement/AssetController.php
+++ b/src/Controller/ContentManagement/AssetController.php
@@ -87,7 +87,7 @@ class AssetController extends AbstractController
         }
         $baseUrl = $request->getBaseUrl() ?? '';
 
-        if (0 !== \strpos($refererPath, $baseUrl)) {
+        if (\strlen($refererPath) > 0 && 0 !== \strpos($refererPath, $baseUrl)) {
             throw new NotFoundHttpException(\sprintf('File %s not found', $requestPath));
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

- bug when the elasticms doen't have bundle
- font have css referer, so assets that match an alias are saved in saved in session for further referer matching