### PR TITLE
fix: delete button no role defined

### DIFF
--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -45,10 +45,8 @@
 								'withView': false,
 								'vertical': false,
 				}%}
-					
-				
-		  
-            {% if false == revision.contentType.hasDeleteRole or is_granted(revision.contentType.deleteRole) %}
+
+            {% if is_granted(revision.contentType.deleteRole) or (false == revision.contentType.hasDeleteRole and is_granted(revision.contentType.createRole)) %}
             	{% if not  revision.contentType.circlesField or attribute(object._source, revision.contentType.circlesField) is not defined or attribute(object._source, revision.contentType.circlesField)|in_my_circles %}
                     {% include '@EMSCore/elements/post-button.html.twig' with {
             			'url':  path('object.delete', {'type': revision.contentType.name, 'ouuid': revision.ouuid} ),

--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -48,7 +48,7 @@
 					
 				
 		  
-            {% if is_granted(revision.contentType.deleteRole) %}
+            {% if false == revision.contentType.hasDeleteRole or is_granted(revision.contentType.deleteRole) %}
             	{% if not  revision.contentType.circlesField or attribute(object._source, revision.contentType.circlesField) is not defined or attribute(object._source, revision.contentType.circlesField)|in_my_circles %}
                     {% include '@EMSCore/elements/post-button.html.twig' with {
             			'url':  path('object.delete', {'type': revision.contentType.name, 'ouuid': revision.ouuid} ),


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

When no delete role is defined, allow delete revisions.