### PR TITLE
fix: datalink not working nested modal

### DIFF
--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -1038,7 +1038,7 @@ class AppExtension extends AbstractExtension
                     'type' => $type,
                     'ouuid' => $ouuid,
                     'revisionId' => $revisionId,
-                ], UrlGeneratorInterface::RELATIVE_PATH).'" '.$addAttribute.' >'.$out.'</a>';
+                ]).'" '.$addAttribute.' >'.$out.'</a>';
         }
 
         return $out;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Only when not viewing the current revision. The datalinks were relative which created the following link: /data/revisions/revisions/page:142c8296e1b8e5e1a82347c26f7dc224af5d10d1