### PR TITLE
fix: archive still not working correct

### DIFF
--- a/src/Core/Revision/Revisions.php
+++ b/src/Core/Revision/Revisions.php
@@ -43,8 +43,8 @@ final class Revisions implements \IteratorAggregate
             $this->entityManager->persist($revision);
 
             if (0 === ++$totalProcessed % $size) {
-                $this->entityManager->clear();
                 $this->entityManager->flush();
+                $this->entityManager->clear();
             }
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

If you bulk more then 250 the archive was not working.
Because entity manager clear was called before