### PR TITLE
fix: hot runtime exception (#734)

### DIFF
--- a/src/Form/DataField/WysiwygFieldType.php
+++ b/src/Form/DataField/WysiwygFieldType.php
@@ -155,10 +155,6 @@ class WysiwygFieldType extends DataFieldType
         $out = parent::viewTransform($data);
 
         if (!\is_string($out)) {
-            throw new \RuntimeException('Unexpected non string WYSIWYG content');
-        }
-
-        if (empty($out)) {
             return '';
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Fix:
 - #734 

 - fix: avoid runtime exception on null/missing $data
 - chore: phpstan fixes : ensure option type

BC:
Some ems:contenttype:import options have renamed

- `bulkSize` to `bulk-size`
- `businessKey` to `business-key`