### PR TITLE
build: fix composer abandoned webpack-encore-pack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 		"symfony/twig-bundle": "^4.4",
 		"symfony/validator": "^4.4",
 		"symfony/web-link": "^4.4",
-		"symfony/webpack-encore-pack": "^1.0",
+		"symfony/webpack-encore-bundle": "^1.0",
 		"symfony/yaml": "^4.4",
 		"symfony/ldap": "^4.4",
 		"ramsey/uuid-doctrine": "^1.6",


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

symfony/webpack-encore-pack
This package is abandoned and no longer maintained. The author suggests using the symfony/webpack-encore-bundle package instead.
