### PR TITLE
fix: deprecate exception initChild

### DIFF
--- a/src/Entity/DataField.php
+++ b/src/Entity/DataField.php
@@ -71,24 +71,11 @@ class DataField implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * @deprecated
-     *
-     * @param int $offset
-     *
-     * @throws \Exception
-     */
-    private function initChild(DataField $child, $offset)
-    {
-        throw new \Exception('deprecate');
-    }
-
-    /**
      * @param mixed $offset
      * @param mixed $value
      */
     public function offsetSet($offset, $value): void
     {
-        $this->initChild($value, $offset);
         $this->children->offsetSet($offset, $value);
     }
 
@@ -99,7 +86,6 @@ class DataField implements \ArrayAccess, \IteratorAggregate
     {
         if ((\is_int($offset) || \ctype_digit($offset)) && !$this->children->offsetExists($offset) && null !== $this->fieldType && $this->fieldType->getChildren()->count() > 0) {
             $value = new DataField();
-            $this->initChild($value, $offset);
             $this->children->offsetSet($offset, $value);
 
             return true;
@@ -121,10 +107,7 @@ class DataField implements \ArrayAccess, \IteratorAggregate
      */
     public function offsetGet($offset)
     {
-        $value = $this->children->offsetGet($offset);
-        $this->initChild($value, $offset);
-
-        return $value;
+        return ('children' === $offset) ? $this->children : $this->children->offsetGet($offset);
     }
 
     public function getIterator()

--- a/src/Resources/views/macros/data-field-type.html.twig
+++ b/src/Resources/views/macros/data-field-type.html.twig
@@ -367,7 +367,7 @@
 	{% endif %}
 
 	<div class="row">
-		{% for child in dataField.children if not child.fieldType.deleted %}
+		{% for child in dataField.children|filter(c => false == c.fieldType.deleted) %}
 		
 			<div class="{% if child.fieldType.displayOptions.class is defined and child.fieldType.displayOptions.class  %}{{ child.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
 				{{ _self.renderDataFieldBlock(child, source, compare, compareRawData) }}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

- remove initChild function only used in DataField.php
- twig is using the offsetGet with offset 'children', just return the children.