### PR TITLE
fix: commands

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -115,6 +115,27 @@ Options:
 * **--search-query**: json escaped string with es query
 * **--dry-run** : will not commit the database transactions
 
+## Environment
+
+### Align
+
+```bash
+Usage:
+  emsco:environment:align [options] [--] <source> <target>
+
+Arguments:
+  source                               Environment source name
+  target                               Environment target name
+
+Options:
+      --scroll-size=SCROLL-SIZE        Size of the elasticsearch scroll request
+      --scroll-timeout=SCROLL-TIMEOUT  Time to migrate "scrollSize" items i.e. 30s or 2m
+      --search-query[=SEARCH-QUERY]    Query used to find elasticsearch records to import [default: "{}"]
+      --force                          If set, the task will be performed (protection)
+      --snapshot                       If set, the target environment will be tagged as a snapshot after the alignment
+      --user=USER                      Lock user [default: "SYSTEM_ALIGN"]
+```
+
 ## Revision
 
 ### Task create

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -107,7 +107,8 @@ Options:
       --scroll-size=SCROLLSIZE        Size of the elasticsearch scroll request
       --scroll-timeout=SCROLLTIMEOUT  Time to migrate "scrollSize" items i.e. 30s or 2m
       --search-query[=SEARCHQUERY]    Query used to find elasticsearch records to transform [default: "{}"]
-      --dry-run                       dry run
+      --dry-run                       Dry run
+      --user=USER                     Lock user [default: "SYSTEM_CONTENT_TRANSFORM"]
 ```
 
 * **--scroll-size**: Size of the elasticsearch scroll request

--- a/src/Command/Environment/AlignCommand.php
+++ b/src/Command/Environment/AlignCommand.php
@@ -25,6 +25,7 @@ class AlignCommand extends AbstractCommand
 
     private Environment $source;
     private Environment $target;
+    private string $user = 'SYSTEM_ALIGN';
 
     private string $searchQuery;
 
@@ -35,6 +36,7 @@ class AlignCommand extends AbstractCommand
     public const OPTION_FORCE = 'force';
     public const OPTION_SEARCH_QUERY = 'search-query';
     public const OPTION_SNAPSHOT = 'snapshot';
+    public const OPTION_USER = 'user';
 
     protected static $defaultName = Commands::ENVIRONMENT_ALIGN;
 
@@ -62,6 +64,7 @@ class AlignCommand extends AbstractCommand
             ->addOption(self::OPTION_SEARCH_QUERY, null, InputOption::VALUE_OPTIONAL, 'Query used to find elasticsearch records to import', '{}')
             ->addOption(self::OPTION_FORCE, null, InputOption::VALUE_NONE, 'If set, the task will be performed (protection)')
             ->addOption(self::OPTION_SNAPSHOT, null, InputOption::VALUE_NONE, 'If set, the target environment will be tagged as a snapshot after the alignment')
+            ->addOption(self::OPTION_USER, null, InputOption::VALUE_REQUIRED, 'Lock user', $this->user)
         ;
     }
 
@@ -77,6 +80,7 @@ class AlignCommand extends AbstractCommand
             $this->revisionSearcher->setTimeout($scrollTimeout);
         }
 
+        $this->user = $this->getOptionString(self::OPTION_USER, $this->user);
         $this->searchQuery = $this->getOptionString(self::OPTION_SEARCH_QUERY);
     }
 
@@ -108,15 +112,17 @@ class AlignCommand extends AbstractCommand
         $bulkSize = $this->revisionSearcher->getSize();
 
         $this->io->note(\sprintf('The source environment contains %s elements, start aligning environments...', $search->getTotal()));
-        $this->io->progressStart($search->getTotal());
 
         $deletedRevision = 0;
         $alreadyAligned = 0;
         $targetIsPreviewEnvironment = [];
 
+        $this->io->progressStart($search->getTotal());
         foreach ($this->revisionSearcher->search($this->source, $search) as $revisions) {
+            $this->revisionSearcher->lock($revisions, $this->user);
             $this->publishService->bulkPublishStart($bulkSize);
-            foreach ($revisions as $revision) {
+
+            foreach ($revisions->transaction() as $revision) {
                 $contentType = $revision->giveContentType();
 
                 if ($revision->getDeleted()) {
@@ -134,9 +140,10 @@ class AlignCommand extends AbstractCommand
 
                 $this->io->progressAdvance();
             }
-            $this->publishService->bulkPublishFinished();
-        }
 
+            $this->publishService->bulkPublishFinished();
+            $this->revisionSearcher->unlock($revisions);
+        }
         $this->io->progressFinish();
 
         if ($input->getOption(self::OPTION_SNAPSHOT)) {

--- a/src/Core/ContentType/Transformer/ContentTransformer.php
+++ b/src/Core/ContentType/Transformer/ContentTransformer.php
@@ -15,8 +15,6 @@ final class ContentTransformer
     private ContentTransformers $transformers;
     private DataService $dataService;
 
-    public const USER = 'SYSTEM_CONTENT_TRANSFORM';
-
     public function __construct(ContentTransformers $transformers, DataService $dataService)
     {
         $this->transformers = $transformers;
@@ -56,7 +54,7 @@ final class ContentTransformer
     /**
      * @param array<mixed> $transformerDefinitions
      */
-    public function transform(Revision $revision, array $transformerDefinitions, bool $dryRun): bool
+    public function transform(Revision $revision, array $transformerDefinitions, string $user, bool $dryRun): bool
     {
         $rawData = $revision->getRawData();
         RecursiveMapper::mapPropertyValue(
@@ -75,9 +73,9 @@ final class ContentTransformer
         }
 
         if (!$dryRun) {
-            $revision = $this->dataService->initNewDraft($revision->getContentTypeName(), $revision->getOuuid(), null, self::USER);
+            $revision = $this->dataService->initNewDraft($revision->getContentTypeName(), $revision->getOuuid(), null, $user);
             $revision->setRawData($rawData);
-            $this->dataService->finalizeDraft($revision, $revisionType, self::USER, false);
+            $this->dataService->finalizeDraft($revision, $revisionType, $user, false);
         }
 
         return true;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -68,6 +68,7 @@
         <service id="ems_core.core_revision_search.revision_searcher" class="EMS\CoreBundle\Core\Revision\Search\RevisionSearcher">
             <argument type="service" id="ems_common.service.elastica"/>
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository"/>
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface"/>
             <argument>%ems_core.default_bulk_size%%</argument>
         </service>
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

# Fixes
- revision searcher no query logging
- align command use transaction with locking (we are signing the rawData)
- align command USER option
- content transform command USER option

# Chores
- add doc align command
