### PR TITLE
fix: job commands

### DIFF
--- a/src/Command/Environment/AlignCommand.php
+++ b/src/Command/Environment/AlignCommand.php
@@ -84,14 +84,13 @@ class AlignCommand extends AbstractCommand
     {
         $this->logger->info('Interact with AlignCommand');
 
-        $this->environmentService->clearCache();
         $environmentNames = $this->environmentService->getEnvironmentNames();
 
         $this->choiceArgumentString(self::ARGUMENT_SOURCE, 'Select an existing environment as source', $environmentNames);
         $this->choiceArgumentString(self::ARGUMENT_TARGET, 'Select an existing environment as target', $environmentNames);
 
-        $this->source = $this->environmentService->giveByName($this->getArgumentString(self::ARGUMENT_SOURCE));
-        $this->target = $this->environmentService->giveByName($this->getArgumentString(self::ARGUMENT_TARGET));
+        $this->source = $this->environmentService->findByName($this->getArgumentString(self::ARGUMENT_SOURCE));
+        $this->target = $this->environmentService->findByName($this->getArgumentString(self::ARGUMENT_TARGET));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -140,8 +139,9 @@ class AlignCommand extends AbstractCommand
         $this->io->progressFinish();
 
         if ($input->getOption(self::OPTION_SNAPSHOT)) {
-            $this->environmentService->setSnapshotTag($this->target);
-            $this->io->note(\sprintf('The target environment "%s" was tagged as a snapshot', $this->target->getName()));
+            $snapShot = $this->environmentService->findByName($this->target->getName());
+            $this->environmentService->setSnapshotTag($snapShot);
+            $this->io->note(\sprintf('The target environment "%s" was tagged as a snapshot', $snapShot->getName()));
         }
 
         if ($deletedRevision > 0) {

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -65,7 +65,7 @@ class JobCommand extends Command
         try {
             $this->jobService->run($job);
         } catch (\Throwable $e) {
-            $this->jobService->finish($job);
+            $this->jobService->finish($job->getId());
             throw $e;
         }
         $interval = \date_diff($start, new \DateTime());

--- a/src/Command/JobOutput.php
+++ b/src/Command/JobOutput.php
@@ -2,31 +2,28 @@
 
 namespace EMS\CoreBundle\Command;
 
-use Doctrine\Bundle\DoctrineBundle\Registry;
-use EMS\CoreBundle\Entity\Job;
+use EMS\CoreBundle\Repository\JobRepository;
 use Symfony\Component\Console\Output\Output;
 
 class JobOutput extends Output
 {
-    /** @var Registry */
-    private $doctrine;
+    private int $jobId;
+    private JobRepository $jobRepository;
 
-    /** @var Job */
-    private $job;
-
-    public function __construct(Registry $doctrine, Job $job)
+    public function __construct(JobRepository $jobRepository, int $jobId)
     {
         parent::__construct();
-        $this->doctrine = $doctrine;
-        $this->job = $job;
+        $this->jobRepository = $jobRepository;
+        $this->jobId = $jobId;
     }
 
     public function doWrite($message, $newline): void
     {
-        $this->job->setStatus($message);
-        $this->job->setOutput($this->job->getOutput().$this->getFormatter()->format($message).($newline ? PHP_EOL : ''));
-        $manager = $this->doctrine->getManager();
-        $manager->persist($this->job);
-        $manager->flush();
+        $job = $this->jobRepository->findOneBy(['id' => $this->jobId]);
+
+        $job->setStatus($message);
+        $job->setOutput($job->getOutput().$this->getFormatter()->format($message).($newline ? PHP_EOL : ''));
+
+        $this->jobRepository->save($job);
     }
 }

--- a/src/Command/JobOutput.php
+++ b/src/Command/JobOutput.php
@@ -19,8 +19,7 @@ class JobOutput extends Output
 
     public function doWrite($message, $newline): void
     {
-        $job = $this->jobRepository->findOneBy(['id' => $this->jobId]);
-
+        $job = $this->jobRepository->findById($this->jobId);
         $job->setStatus($message);
         $job->setOutput($job->getOutput().$this->getFormatter()->format($message).($newline ? PHP_EOL : ''));
 

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -11,13 +11,7 @@ class JobRepository extends EntityRepository
 {
     public function findById(int $jobId): Job
     {
-        $qb = $this->createQueryBuilder('j');
-        $query = $qb
-            ->andWhere($qb->expr()->eq('j.id', ':job_id'))
-            ->setParameter('job_id', $jobId)
-            ->getQuery();
-
-        $job = $query->getSingleResult();
+        $job = $this->findOneBy(['id' => $jobId]);
 
         if (!$job instanceof Job) {
             throw new \RuntimeException('Job not found');

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -5,9 +5,27 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use EMS\CoreBundle\Entity\Job;
 
 class JobRepository extends EntityRepository
 {
+    public function findById(int $jobId): Job
+    {
+        $qb = $this->createQueryBuilder('j');
+        $query = $qb
+            ->andWhere($qb->expr()->eq('j.id', ':job_id'))
+            ->setParameter('job_id', $jobId)
+            ->getQuery();
+
+        $job = $query->getSingleResult();
+
+        if (!$job instanceof Job) {
+            throw new \RuntimeException('Job not found');
+        }
+
+        return $job;
+    }
+
     public function countJobs(): int
     {
         return \intval($this->createQueryBuilder('a')
@@ -30,6 +48,6 @@ class JobRepository extends EntityRepository
     public function save(Job $job): void
     {
         $this->getEntityManager()->persist($job);
-        $this->getEntityManager()->flush();;
+        $this->getEntityManager()->flush();
     }
 }

--- a/src/Repository/JobRepository.php
+++ b/src/Repository/JobRepository.php
@@ -26,4 +26,10 @@ class JobRepository extends EntityRepository
 
         return \intval($qb->getQuery()->getSingleScalarResult());
     }
+
+    public function save(Job $job): void
+    {
+        $this->getEntityManager()->persist($job);
+        $this->getEntityManager()->flush();;
+    }
 }

--- a/src/Service/EnvironmentService.php
+++ b/src/Service/EnvironmentService.php
@@ -47,6 +47,8 @@ class EnvironmentService
     /** @var string */
     private $instanceId;
 
+    private EnvironmentRepository $environmentRepository;
+
     public function __construct(
         Registry $doctrine,
         Session $session,
@@ -63,6 +65,8 @@ class EnvironmentService
         $this->logger = $logger;
         $this->elasticaService = $elasticaService;
         $this->instanceId = $instanceId;
+
+        $this->environmentRepository = $doctrine->getRepository(Environment::class);
     }
 
     public function createEnvironment(string $name, bool $updateReferrers = false): Environment
@@ -99,6 +103,8 @@ class EnvironmentService
 
     public function setSnapshotTag(Environment $environment, bool $value = true): void
     {
+        $this->doctrine->getManager()->refresh($environment);
+
         $environment->setSnapshot($value);
 
         $em = $this->doctrine->getManager();
@@ -115,7 +121,7 @@ class EnvironmentService
             return $this->environments;
         }
 
-        $environments = $this->doctrine->getManager()->getRepository('EMSCoreBundle:Environment')->findAll();
+        $environments = $this->environmentRepository->findAll();
 
         /** @var Environment $environment */
         foreach ($environments as $environment) {
@@ -244,6 +250,11 @@ class EnvironmentService
         }
 
         return false;
+    }
+
+    public function findByName(string $name): Environment
+    {
+        return $this->environmentRepository->findOneByName($name);
     }
 
     public function giveByName(string $name): Environment

--- a/src/Service/EnvironmentService.php
+++ b/src/Service/EnvironmentService.php
@@ -66,7 +66,11 @@ class EnvironmentService
         $this->elasticaService = $elasticaService;
         $this->instanceId = $instanceId;
 
-        $this->environmentRepository = $doctrine->getRepository(Environment::class);
+        $environmentRepository = $doctrine->getRepository(Environment::class);
+        if (!$environmentRepository instanceof EnvironmentRepository) {
+            throw new \RuntimeException('Not found repository');
+        }
+        $this->environmentRepository = $environmentRepository;
     }
 
     public function createEnvironment(string $name, bool $updateReferrers = false): Environment
@@ -103,8 +107,6 @@ class EnvironmentService
 
     public function setSnapshotTag(Environment $environment, bool $value = true): void
     {
-        $this->doctrine->getManager()->refresh($environment);
-
         $environment->setSnapshot($value);
 
         $em = $this->doctrine->getManager();

--- a/src/Service/JobService.php
+++ b/src/Service/JobService.php
@@ -143,9 +143,9 @@ class JobService
         return $output;
     }
 
-    public function finish(string $jobId): void
+    public function finish(int $jobId): void
     {
-        $job = $this->repository->findOneBy(['id' => $jobId]);
+        $job = $this->repository->findById($jobId);
         $job->setDone(true);
         $job->setProgress(100);
 

--- a/src/Service/JobService.php
+++ b/src/Service/JobService.php
@@ -120,7 +120,7 @@ class JobService
             $output->writeln('Exception:'.$e->getMessage());
         }
 
-        $this->finish($job);
+        $this->finish($job->getId());
     }
 
     /**
@@ -133,20 +133,19 @@ class JobService
 
     public function start(Job $job): JobOutput
     {
-        $output = new JobOutput($this->doctrine, $job);
+        $job->setStarted(true);
+        $this->repository->save($job);
+
+        $output = new JobOutput($this->repository, $job->getId());
         $output->setDecorated(true);
         $output->writeln('Job ready to be launch');
-
-        $job->setStarted(true);
-
-        $this->em->persist($job);
-        $this->em->flush();
 
         return $output;
     }
 
-    public function finish(Job $job): void
+    public function finish(string $jobId): void
     {
+        $job = $this->repository->findOneBy(['id' => $jobId]);
         $job->setDone(true);
         $job->setProgress(100);
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

- fix: align command update snapshot
> Because the align command uses a transaction -> doctrine clear. We need to do a new findByName before updating the snapshot environment.

- fix: job with sub commands 
> The job output and finish should fetch the job entity again. Because the command or multiple sub commands can clear doctrine for performance reasons.
