### PR TITLE
fix: use PdfPrinterInterface

### DIFF
--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\NoResultException;
 use EMS\CommonBundle\Elasticsearch\Response\Response as CommonResponse;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
-use EMS\CommonBundle\Service\Pdf\DomPdfPrinter;
 use EMS\CommonBundle\Service\Pdf\Pdf;
+use EMS\CommonBundle\Service\Pdf\PdfPrinterInterface;
 use EMS\CommonBundle\Service\Pdf\PdfPrintOptions;
 use EMS\CoreBundle\Controller\AppController;
 use EMS\CoreBundle\EMSCoreBundle;
@@ -840,7 +840,7 @@ class DataController extends AppController
      * @Route("/data/custom-view/{environmentName}/{templateId}/{ouuid}/{_download}", defaults={"_download"=false, "public"=false}, name="data.customview")
      * @Route("/data/template/{environmentName}/{templateId}/{ouuid}/{_download}", defaults={"_download"=false, "public"=false}, name="ems_data_custom_template_protected")
      */
-    public function customViewAction($environmentName, $templateId, $ouuid, $_download, $public, LoggerInterface $logger, TranslatorInterface $translator, SearchService $searchService, TwigEnvironment $twig, DomPdfPrinter $pdfPrinter)
+    public function customViewAction($environmentName, $templateId, $ouuid, $_download, $public, LoggerInterface $logger, TranslatorInterface $translator, SearchService $searchService, TwigEnvironment $twig, PdfPrinterInterface $pdfPrinter)
     {
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Cannot autowire argument $pdfPrinter of "EMS\CoreBundle\Controller\ContentManagement\DataController::customViewAction()": it references class "EMS\CommonBundle\Service\Pdf\DomPdfPrinter" but no such service exists. Try changing the type-hint to "EMS\CommonBundle\Service\Pdf\PdfPrinterInterface" instead.