### PR TITLE
fix(css): wrong bootstrap fonts path

### DIFF
--- a/assets/css/_bootstrap-variables.scss
+++ b/assets/css/_bootstrap-variables.scss
@@ -1,2 +1,2 @@
 
-$icon-font-path: $node-modules-path + "bootstrap/fonts/";
+$icon-font-path: $node-modules-path + "bootstrap-sass/assets/fonts/bootstrap/";


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	