### PR TITLE
fix: exception on mapping error

### DIFF
--- a/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/src/Resources/translations/EMSCoreBundle.en.yml
@@ -395,7 +395,7 @@ service.contenttype.mappings_updated: 'Mappings successfully updated/created for
 service.contenttype.pipelines: 'Pipelines have been updated/created for %contenttype%'
 service.contenttype.pipelines_error: 'elasticms was not able to generate pipelines for the content type %contenttype%, they are disabled. Please consider to update your elasticsearch cluster (>=5.0). %elasticsearch_error_type% : %elasticsearch_error_reason%'
 service.contenttype.reordered: 'Content type "%contenttype% has been reordered'
-service.contenttype.should_reindex: 'You should try to rebuild the indexes for  %contenttype%. Message from Elasticsearch; %elasticsearch_error_type% : %elasticsearch_error_reason%'
+service.contenttype.update_mapping_exception: 'Error on updating %environments%''s mapping : %elasticsearch_error%'
 service.data.already_unpublished: 'The revision ems://revision:%revision_id% of the document ems://object:%contenttype%:%ouuid% was already deleted from %environment%'
 service.data.cant_be_finalized: 'The revision ems://revision:%revision_id% of the document ems://object:%contenttype%:%ouuid% can''t be finalized as it is (see previous warnings)'
 service.data.cant_finalize_field: '%error_message%'

--- a/src/Service/ContentTypeService.php
+++ b/src/Service/ContentTypeService.php
@@ -3,7 +3,7 @@
 namespace EMS\CoreBundle\Service;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
-use Elasticsearch\Common\Exceptions\BadRequest400Exception;
+use Elastica\Exception\ResponseException;
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Search\Search;
@@ -211,18 +211,17 @@ class ContentTypeService
             $em = $this->doctrine->getManager();
             $em->persist($contentType);
             $em->flush();
-        } catch (BadRequest400Exception $e) {
+        } catch (ResponseException $e) {
             $contentType->setDirty(true);
-            $message = \json_decode($e->getMessage(), true);
+            $message = $e->getMessage();
             if (!empty($e->getPrevious())) {
-                $message = \json_decode($e->getPrevious()->getMessage(), true);
+                $message = $e->getPrevious()->getMessage();
             }
 
-            $this->logger->error('service.contenttype.should_reindex', [
+            $this->logger->error('service.contenttype.update_mapping_exception', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),
                 'environments' => $envs,
-                'elasticsearch_error_type' => $message['error']['type'],
-                'elasticsearch_error_reason' => $message['error']['reason'],
+                'elasticsearch_error' => $message,
             ]);
         }
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Displays a message instead of a 500 error page on updating mapping