### PR TITLE
fix: role picker type not required by default

### DIFF
--- a/src/Form/Field/RolePickerType.php
+++ b/src/Form/Field/RolePickerType.php
@@ -21,6 +21,7 @@ class RolePickerType extends SelectPickerType
         $choices = \array_merge(['role.not-defined' => null], $this->userService->listUserRoles());
 
         $resolver->setDefaults([
+            'required' => false,
             'choices' => $choices,
             'attr' => ['data-live-search' => true],
             'choice_attr' => function () {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

In [29a5e5d140005d00331d1fe1c47e4c3fa410ced2](https://github.com/ems-project/EMSCoreBundle/pull/836/commits/45ca943a6247587abff454342d10f241361ad8a9)  makes the role pickers required