### PR TITLE
fix: by default edit is granted if no minimal role is defined

### DIFF
--- a/src/Core/Revision/Json/JsonMenuNestedDefinition.php
+++ b/src/Core/Revision/Json/JsonMenuNestedDefinition.php
@@ -187,6 +187,9 @@ final class JsonMenuNestedDefinition
     private function isGrantedFieldType(FieldType $fieldType): bool
     {
         $fieldMinimumRole = $fieldType->getRestrictionOption('minimum_role');
+        if (!\is_string($fieldMinimumRole) || '' === $fieldMinimumRole) {
+            return true;
+        }
 
         return $this->authorizationChecker->isGranted($fieldMinimumRole);
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Previously editable JSON nested field are now readonly