### PR TITLE
fix: add body class wysiwyg preview

### DIFF
--- a/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
+++ b/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
@@ -13,7 +13,7 @@
         {% endif %}
     {% endapply %}
 </head>
-<body>
+<body class="wysiwyg-preview">
 {% if null != styleSet.contentJs %}
     <script src="{{ asset(styleSet.contentJs, styleSet.saveDir == null ? 'emsch' : null) }}"></script>
 {% endif %}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Add body class so that we can target the preview rendering

Example:

```css
    .pageBody .content,
    body.wysiwyg-preview, 
    body.cke_editable {
        &>* {
            margin-bottom: $px15;
            margin-left: 0!important;
        }
```
