### PR TITLE
fix: export's filenames

### DIFF
--- a/src/Command/ExportDocumentsCommand.php
+++ b/src/Command/ExportDocumentsCommand.php
@@ -232,16 +232,21 @@ class ExportDocumentsCommand extends EmsCommand
                 if (false === $result) {
                     continue;
                 }
-                if (null !== $contentType->getBusinessIdField() && isset($result->getData()[$contentType->getBusinessIdField()])) {
-                    $filename = $result->getData()[$contentType->getBusinessIdField()].$extension;
-                } else {
-                    $filename = $result->getId().$extension;
-                }
 
                 if ($withBusinessId) {
                     $document = $this->dataService->hitToBusinessDocument($contentType, $result->getHit());
                 } else {
                     $document = new Document($contentType->getName(), $result->getId(), $result->getData());
+                }
+
+                if ($useTemplate && $this->templateService->hasFilenameTemplate()) {
+                    $filename = $this->templateService->renderFilename($document, $contentType, $environmentName, [
+                        'loop' => $loop,
+                    ]);
+                } elseif (null !== $contentType->getBusinessIdField() && isset($result->getData()[$contentType->getBusinessIdField()])) {
+                    $filename = $result->getData()[$contentType->getBusinessIdField()].$extension;
+                } else {
+                    $filename = $result->getId().$extension;
                 }
 
                 if ($useTemplate) {

--- a/src/Entity/Template.php
+++ b/src/Entity/Template.php
@@ -516,12 +516,7 @@ class Template extends JsonDeserializer implements \JsonSerializable, EntityInte
         return $this;
     }
 
-    /**
-     * Get filename.
-     *
-     * @return string
-     */
-    public function getFilename()
+    public function getFilename(): ?string
     {
         return $this->filename;
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Since the document export is usin a command to generate the exports the filename template is ignored. This is the related fix.