### PR TITLE
fix: reordered not defined

### DIFF
--- a/src/Resources/views/form/forms.html.twig
+++ b/src/Resources/views/form/forms.html.twig
@@ -318,7 +318,7 @@
                     </div>
                 {% endif %}
             </div>
-            {%  if table.sortable and table.supportsTableActions %}
+            {%  if attribute(form, 'reordered') is defined and table.supportsTableActions %}
                 <div class="modal fade" id="{{ table.attributeName|e('html_attr') }}_modal_reorder" tabindex="-1" role="dialog" aria-labelledby="{{ table.attributeName|e('html_attr') }}_modal_reorder_label">
                     <div class="modal-dialog" role="document">
                         <div class="modal-content">


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

See src/Form/Form/TableType.php line 73:
if ($data->isSortable() && $data->count() > 1) { ... }

If the datatable only contains 1 record we get an error.

Error:
Neither the property "reordered" nor one of the methods "reordered()", "getreordered()"/"isreordered()"/"hasreordered()" or "__call()" exist and have public access in class "Symfony\Component\Form\FormView".