### PR TITLE
fix: save and publish not current revision

### DIFF
--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -179,6 +179,11 @@ class EditController extends AbstractController
                     $revision = $this->revisionService->saveVersion($revision, $objectArray, $versionTag, $form);
                 } else {
                     $this->revisionService->save($revision, $objectArray);
+                    if (null !== $revision->getEndTime()) {
+                        foreach ($revision->getEnvironments() as $publishedEnvironment) {
+                            $this->publishService->publish($revision, $publishedEnvironment);
+                        }
+                    }
                 }
 
                 if (isset($requestRevision['publish'])) {//Finalize


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

If we edit a not aligned revision, we need to publish the revision on save in the published environments.