### PR TITLE
fix: table cellRender order in js

### DIFF
--- a/src/Core/Revision/Task/TaskTableService.php
+++ b/src/Core/Revision/Task/TaskTableService.php
@@ -58,6 +58,7 @@ final class TaskTableService implements EntityServiceInterface
 
             if ('block' === $type) {
                 $def = new TemplateBlockTableColumn($options['label'], $name, self::TEMPLATE, $orderField);
+                $def->setCellRender(self::COL_DEADLINE !== $name);
                 $table->addColumnDefinition($def)->setCellClass('col-'.$name);
             } else {
                 $table->addColumn($options['label'], $name);

--- a/src/Form/Data/TableColumn.php
+++ b/src/Form/Data/TableColumn.php
@@ -17,6 +17,7 @@ class TableColumn
     private ?\Closure $itemIconCallback = null;
     private string $cellType = 'td';
     private string $cellClass = '';
+    private bool $cellRender = true;
     /** @var array <string, \Closure> */
     private array $htmlAttributes = [];
     private ?\Closure $pathCallback = null;
@@ -66,6 +67,16 @@ class TableColumn
         $this->routeName = $name;
         $this->routeParametersCallback = $callback;
         $this->routeTarget = $target;
+    }
+
+    public function cellRender(): bool
+    {
+        return $this->cellRender;
+    }
+
+    public function setCellRender(bool $value): void
+    {
+        $this->cellRender = $value;
     }
 
     public function getRouteName(): ?string

--- a/src/Form/Data/TemplateTableColumn.php
+++ b/src/Form/Data/TemplateTableColumn.php
@@ -13,6 +13,7 @@ class TemplateTableColumn extends TableColumn
     private const ORDER_FIELD = 'orderField';
     private const CELL_TYPE = 'cellType';
     private const CELL_CLASS = 'cellClass';
+    private const CELL_RENDER = 'cellRender';
     private bool $orderable;
     private string $template;
 
@@ -27,6 +28,7 @@ class TemplateTableColumn extends TableColumn
         parent::__construct($options[self::LABEL], $options[self::ORDER_FIELD] ?? 'not orderable');
         $this->setCellClass($options[self::CELL_CLASS]);
         $this->setCellType($options[self::CELL_TYPE]);
+        $this->setCellRender($options[self::CELL_RENDER]);
     }
 
     public function getOrderable(): bool
@@ -47,7 +49,7 @@ class TemplateTableColumn extends TableColumn
     /**
      * @param array<string, mixed> $options
      *
-     * @return array{label: string, template: string, orderField: string|null, cellType: string, cellClass: string}
+     * @return array{label: string, template: string, orderField: string|null, cellType: string, cellClass: string, cellRender: bool}
      */
     private static function resolveOptions(array $options)
     {
@@ -59,14 +61,16 @@ class TemplateTableColumn extends TableColumn
                 self::ORDER_FIELD => null,
                 self::CELL_TYPE => 'td',
                 self::CELL_CLASS => '',
+                self::CELL_RENDER => true,
             ])
             ->setAllowedTypes(self::LABEL, ['string'])
             ->setAllowedTypes(self::TEMPLATE, ['string'])
             ->setAllowedTypes(self::ORDER_FIELD, ['string', 'null'])
             ->setAllowedTypes(self::CELL_TYPE, ['string'])
             ->setAllowedTypes(self::CELL_CLASS, ['string'])
+            ->setAllowedTypes(self::CELL_RENDER, ['bool'])
         ;
-        /** @var array{label: string, template: string, orderField: string|null, cellType: string, cellClass: string} $resolvedParameter */
+        /** @var array{label: string, template: string, orderField: string|null, cellType: string, cellClass: string, cellRender: bool} $resolvedParameter */
         $resolvedParameter = $resolver->resolve($options);
 
         return $resolvedParameter;

--- a/src/Resources/views/form/forms.html.twig
+++ b/src/Resources/views/form/forms.html.twig
@@ -175,9 +175,11 @@
 {% endblock emsco_form_table_column_data_value %}
 
 {% block emsco_form_table_column_data %}
-    <td>
+    {% if column.cellRender %}
+        <td>{{ block(column.tableDataValueBlock()) }}</td>
+    {% else %}
         {{ block(column.tableDataValueBlock()) }}
-    </td>
+    {% endif %}
 {% endblock emsco_form_table_column_data %}
 
 {% block emsco_form_table_column_action_checkbox %}

--- a/src/Resources/views/revision/task/columns.twig
+++ b/src/Resources/views/revision/task/columns.twig
@@ -18,14 +18,16 @@
 {% endblock %}
 
 {%- block deadline -%}
-    {%- if data.taskCurrent.hasDeadline -%}
-        {%- set deadline = data.taskCurrent.deadline.format(date_format) -%}
-        {%- if data.taskCurrent.deadline.timestamp < date('now').timestamp -%}
-            <span class="text-danger"><strong>{{ deadline }}</strong></span>
-        {%- else -%}
-            {{ deadline }}
+    <td data-order="{{ data.taskCurrent.hasDeadline ? data.taskCurrent.deadline.timestamp : 0 }}">
+        {%- if data.taskCurrent.hasDeadline -%}
+            {%- set deadline = data.taskCurrent.deadline.format(date_format) -%}
+            {%- if data.taskCurrent.deadline.timestamp < date('now').timestamp -%}
+                <span class="text-danger"><strong>{{ deadline }}</strong></span>
+            {%- else -%}
+                {{ deadline }}
+            {%- endif -%}
         {%- endif -%}
-    {%- endif -%}
+    </td>
 {%- endblock -%}
 
 {%- block actions -%}


### PR DESCRIPTION

|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Allow to generate the cell in a custom template, by setting cellRender to false.