### PR TITLE
feat: revision task dashboard

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -57,10 +57,6 @@ final class DashboardController extends AbstractController
             return $this->redirectToRoute(Routes::DASHBOARD, ['name' => $dashboard->getName()]);
         }
 
-        if ($this->taskManager->hasDashboard()) {
-            return $this->redirectToRoute('ems_core_task_dashboard');
-        }
-
         return $this->redirectToRoute('notifications.inbox');
     }
 }

--- a/src/Controller/Revision/TaskController.php
+++ b/src/Controller/Revision/TaskController.php
@@ -13,7 +13,6 @@ use EMS\CoreBundle\Core\UI\AjaxService;
 use EMS\CoreBundle\Form\Data\EntityTable;
 use EMS\CoreBundle\Form\Field\SelectUserPropertyType;
 use EMS\CoreBundle\Form\Form\RevisionTaskType;
-use EMS\CoreBundle\Form\Form\TableType;
 use EMS\CoreBundle\Helper\DataTableRequest;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -43,20 +42,6 @@ final class TaskController extends AbstractController
         $this->ajax = $ajax;
         $this->formFactory = $formFactory;
         $this->tableExporter = $tableExporter;
-    }
-
-    public function dashboard(Request $request, string $tab): Response
-    {
-        $table = $this->getTable($tab);
-        $form = $this->createForm(TableType::class, $table);
-        $form->handleRequest($request);
-
-        return $this->render('@EMSCore/revision/task/dashboard.html.twig', [
-            'table' => $table,
-            'formTable' => $form->createView(),
-            'currentTab' => $tab,
-            'tabs' => $this->taskManager->getDashboardTabs(),
-        ]);
     }
 
     public function ajaxDataTable(Request $request, string $tab): Response

--- a/src/Core/Dashboard/Services/RevisionTask.php
+++ b/src/Core/Dashboard/Services/RevisionTask.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\Dashboard\Services;
+
+use EMS\CoreBundle\Core\Revision\Task\TaskManager;
+use EMS\CoreBundle\Entity\Dashboard;
+use EMS\CoreBundle\Form\Form\TableType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+
+final class RevisionTask extends AbstractType implements DashboardInterface
+{
+    private Environment $twig;
+    private RouterInterface $router;
+    private RequestStack $requestStack;
+    private FormFactoryInterface $formFactory;
+    private TaskManager $taskManager;
+
+    public function __construct(
+        Environment $twig,
+        RouterInterface $router,
+        RequestStack $requestStack,
+        FormFactoryInterface $formFactory,
+        TaskManager $taskManager)
+    {
+        $this->twig = $twig;
+        $this->router = $router;
+        $this->requestStack = $requestStack;
+        $this->formFactory = $formFactory;
+        $this->taskManager = $taskManager;
+    }
+
+    public function getResponse(Dashboard $dashboard): Response
+    {
+        /** @var Request $request */
+        $request = $this->requestStack->getCurrentRequest();
+        $tab = $request->get('tab', 'user');
+        $tabs = $this->taskManager->getDashboardTabs();
+
+        if (!\in_array($tab, $tabs, true)) {
+            throw new NotFoundHttpException(\sprintf('Could not find tab %s', $tab));
+        }
+
+        $tableUrl = $this->router->generate('ems_core_task_ajax_datatable', ['tab' => $tab]);
+        $table = $this->taskManager->getTable($tableUrl, $tab, false);
+
+        $form = $this->formFactory->create(TableType::class, $table);
+        $form->handleRequest($request);
+
+        return new Response($this->twig->render('@EMSCore/revision/task/dashboard.html.twig', [
+            'table' => $table,
+            'formTable' => $form->createView(),
+            'currentTab' => $tab,
+            'tabs' => $tabs,
+        ]));
+    }
+}

--- a/src/Core/Revision/Task/TaskManager.php
+++ b/src/Core/Revision/Task/TaskManager.php
@@ -139,23 +139,11 @@ final class TaskManager
         return $revision->hasTaskCurrent() ? $revision->getTaskCurrent() : null;
     }
 
-    public function hasDashboard(): bool
-    {
-        return $this->isTaskUser() || $this->isTaskOwner() || $this->isTaskManager();
-    }
-
     public function isTaskAssignee(Task $task): bool
     {
         $user = $this->userService->getCurrentUser();
 
         return $task->getAssignee() === $user->getUsername();
-    }
-
-    public function isTaskUser(): bool
-    {
-        $user = $this->userService->getCurrentUser();
-
-        return $this->taskRepository->countForUser($user) > 0;
     }
 
     public function isTaskOwner(): bool

--- a/src/Resources/config/dashboards.xml
+++ b/src/Resources/config/dashboards.xml
@@ -23,5 +23,14 @@
             <tag name="ems.dashboard" alias="export" />
             <tag name="form.type" />
         </service>
+        <service id="ems_core.dashboard.revision_task" class="EMS\CoreBundle\Core\Dashboard\Services\RevisionTask">
+            <argument type="service" id="twig" />
+            <argument type="service" id="router" />
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="form.factory" />
+            <argument type="service" id="ems_core.core_revision_task.task_manager" />
+            <tag name="ems.dashboard" alias="revision_task" />
+            <tag name="form.type" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/routing/task.xml
+++ b/src/Resources/config/routing/task.xml
@@ -4,11 +4,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="ems_core_task_dashboard" path="/tasks/dashboard/{tab}" methods="GET">
-        <requirement key="tab">user|owner|manager</requirement>
-        <default key="tab">user</default>
-        <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::dashboard</default>
-    </route>
     <route id="ems_core_task_ajax_datatable" path="/tasks/dashboard/{tab}.json" methods="GET POST">
         <requirement key="tab">user|owner|manager</requirement>
         <default key="tab">user</default>

--- a/src/Resources/translations/emsco-twigs.en.yml
+++ b/src/Resources/translations/emsco-twigs.en.yml
@@ -130,6 +130,7 @@ ems_core.dashboard.template.icon: 'fa fa-html5'
 ems_core.dashboard.template.label: Template
 ems_core.dashboard.export.icon: 'glyphicon glyphicon-export'
 ems_core.dashboard.export.label: Export
+ems_core.dashboard.revision_task.label: 'Revision tasks'
 views.elements.sidebar-menu-html.dashboards: Dashboards
 views.elements.sidebar-menu-html.content-types: 'Content Types'
 dashboard.exception.title: 'The dashboard %name% raised an exception'

--- a/src/Resources/views/revision/task/dashboard.html.twig
+++ b/src/Resources/views/revision/task/dashboard.html.twig
@@ -15,7 +15,9 @@
                 </li>
             {% else %}
                 <li>
-                    <a href="{{ path('ems_core_task_dashboard', {'tab': tabName}) }}">{{ "task.dashboard.tab.#{tabName}"|trans }}</a>
+                    <a href="{{ path(app.request.get('_route'), app.request.get('_route_params')|merge({'tab': tabName})) }}">
+                        {{ "task.dashboard.tab.#{tabName}"|trans }}
+                    </a>
                 </li>
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Move revision task overview route to a dashboard. This way it can be available on in the sidebar or even default landing page.