### PR TITLE
fix: export revision task from dashboard

### DIFF
--- a/src/Core/DataTable/TableRenderer.php
+++ b/src/Core/DataTable/TableRenderer.php
@@ -65,6 +65,7 @@ final class TableRenderer
             $row = \json_decode($template->render([
                 'table' => $table,
                 'line' => $line,
+                'export' => true,
             ]));
             if (!\is_array($row)) {
                 throw new \RuntimeException('Unexpected non array object');

--- a/src/Core/Revision/Task/TaskTableService.php
+++ b/src/Core/Revision/Task/TaskTableService.php
@@ -29,7 +29,7 @@ final class TaskTableService implements EntityServiceInterface
     public const COLUMNS = [
         self::COL_TITLE => ['type' => 'block', 'column' => 'taskTitle', 'mapping' => 't.title'],
         self::COL_DOCUMENT => ['column' => 'label', 'mapping' => 'r.labelField'],
-        self::COL_DOCUMENT_VERSION => ['type' => 'block', 'column' => 'version', 'mapping' => 'r.versionTag'],
+        self::COL_DOCUMENT_VERSION => ['type' => 'block', 'column' => 'versionTag', 'mapping' => 'r.versionTag'],
         self::COL_OWNER => ['type' => 'block', 'column' => 'owner', 'mapping' => 'r.owner'],
         self::COL_ASSIGNEE => ['type' => 'block', 'column' => 'taskAssignee', 'mapping' => 't.assignee'],
         self::COL_STATUS => ['type' => 'block', 'column' => 'taskStatus', 'mapping' => 't.status'],

--- a/src/Resources/views/form/forms.html.twig
+++ b/src/Resources/views/form/forms.html.twig
@@ -143,6 +143,7 @@
 {% endblock emsco_form_table_column_data_user %}
 
 {% block emsco_form_table_column_data_label_prefix -%}
+{%- if export|default(false) == false -%}
     <div{{ block('emsco_form_table_column_data_html_atributes')  }}>
     {%- if column.routeName and column.getRouteProperties(line.data)-%}
         <a href="{{ path(column.routeName, column.getRouteProperties(line.data)) }}" {% if column.routeTarget %}target="{{ column.routeTarget }}"{% endif %}>
@@ -152,13 +153,16 @@
     {%- if column.itemIconClass(line.data) -%}
         <i class="{{ column.itemIconClass(line.data) }}"></i>&nbsp;
     {%- endif -%}
+{%- endif -%}
 {%- endblock emsco_form_table_column_data_label_prefix %}
 
 {% block emsco_form_table_column_data_label_suffix -%}
+{%- if export|default(false) == false -%}
     {%- if (column.routeName and column.getRouteProperties(line.data)) or column.hasPath(line.data, app.request.baseUrl) -%}
         </a>
     {%- endif -%}
     </div>
+{%- endif -%}
 {% endblock emsco_form_table_column_data_label_suffix -%}
 
 {% block emsco_form_table_column_data_html_atributes %}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The revision task dashboard export was containing '<div>value</div>' and version was exported instead of versionTag