### PR TITLE
fix: reorder ct from 1

### DIFF
--- a/src/Controller/ContentManagement/ContentTypeController.php
+++ b/src/Controller/ContentManagement/ContentTypeController.php
@@ -362,7 +362,7 @@ class ContentTypeController extends AppController
         if ($request->isMethod('POST')) {
             $form = $request->get('form');
             if (isset($form['contentTypeNames']) && \is_array($form['contentTypeNames'])) {
-                $counter = 0;
+                $counter = 1;
                 foreach ($form['contentTypeNames'] as $name) {
                     /** @var ContentType $contentType */
                     $contentType = $contentTypeRepository->findOneBy([


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Otherwise the first ct will have it at 0, and on reimport it will be pushed to the end of the list