### PR TITLE
fix: publish and align versioned revision

### DIFF
--- a/src/Controller/ContentManagement/PublishController.php
+++ b/src/Controller/ContentManagement/PublishController.php
@@ -37,6 +37,9 @@ class PublishController extends AbstractController
      */
     public function publishToAction(Revision $revisionId, Environment $envId, PublishService $publishService): Response
     {
+        $revision = $revisionId;
+        $environment = $envId;
+
         $contentType = $revisionId->getContentType();
         if (null === $contentType) {
             throw new \RuntimeException('Content type not found');
@@ -46,15 +49,19 @@ class PublishController extends AbstractController
         }
 
         try {
-            $publishService->publish($revisionId, $envId);
+            if ($revisionId->hasVersionTag()) {
+                $publishService->publishAndAlignVersions($revision, $environment);
+            } else {
+                $publishService->publish($revision, $environment);
+            }
         } catch (NonUniqueResultException $e) {
             throw new NotFoundHttpException('Revision not found');
         }
 
         return $this->redirectToRoute(Routes::VIEW_REVISIONS, [
-            'ouuid' => $revisionId->getOuuid(),
+            'ouuid' => $revision->getOuuid(),
             'type' => $contentType->getName(),
-            'revisionId' => $revisionId->getId(),
+            'revisionId' => $revision->getId(),
         ]);
     }
 

--- a/src/Repository/RevisionRepository.php
+++ b/src/Repository/RevisionRepository.php
@@ -2,7 +2,6 @@
 
 namespace EMS\CoreBundle\Repository;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityRepository;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

When we publish a revision that is sharing a version_uuid with other revisions, we need to align/publish also the other revisions.
Otherwise you can have multiple currents revisions in a environment.

