### PR TITLE
fix: revision label calculation and versioned

### DIFF
--- a/src/Entity/Revision.php
+++ b/src/Entity/Revision.php
@@ -1182,7 +1182,7 @@ class Revision implements EntityInterface
         return $this->versionUuid;
     }
 
-    public function getVersionDate(string $field): ?\DateTimeInterface
+    public function getVersionDate(string $field): ?\DateTimeImmutable
     {
         if (null === $contentType = $this->contentType) {
             throw new \RuntimeException(\sprintf('ContentType not found for revision %d', $this->getId()));


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

When the revision is versioned the label format should be %versionTag% - %label% (%fromDate% - %toDate%)

But also the getLabel should first check the rawData for the label, and fallback to the labelField in the entity. This way when the label changes we receive a correct flash.