### PR TITLE
fix: default value selectUserPropertyFieldType

### DIFF
--- a/src/Form/DataField/SelectUserPropertyFieldType.php
+++ b/src/Form/DataField/SelectUserPropertyFieldType.php
@@ -69,6 +69,8 @@ final class SelectUserPropertyFieldType extends DataFieldType
             'user_property' => $options['user_property'],
             'user_roles' => $options['user_roles'],
             'event_dispatcher' => $builder->getEventDispatcher(),
+            'required' => false,
+            'empty_data' => $options['multiple'] ? [] : null,
         ]);
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Fix the selectUserProperty FieldType is now always selecting the first value, we should just not make it required for symfony. The mandatory check on the mapping will add the required assertion.