### PR TITLE
fix: json menu nested level

### DIFF
--- a/src/Resources/views/revision/json/json_menu_nested.html.twig
+++ b/src/Resources/views/revision/json/json_menu_nested.html.twig
@@ -45,8 +45,8 @@
         {{ block('itemDisplay') }}
         {% if item is defined and item.children|default([])|length > 0 %}
             <ol class="json-menu-nested-list collapse" data-list="{{ item.id }}">
+                {%- set level = level + 1 -%}
                 {%- for childItem in item.children|default([]) -%}
-                    {%- set level = level + 1 -%}
                     {%- with { 'item': childItem } -%}{{ block('renderItem') }}{% endwith %}
                 {% endfor %}
             </ol>

--- a/src/Resources/views/revision/json/json_menu_nested.html.twig
+++ b/src/Resources/views/revision/json/json_menu_nested.html.twig
@@ -45,9 +45,8 @@
         {{ block('itemDisplay') }}
         {% if item is defined and item.children|default([])|length > 0 %}
             <ol class="json-menu-nested-list collapse" data-list="{{ item.id }}">
-                {%- set level = level + 1 -%}
                 {%- for childItem in item.children|default([]) -%}
-                    {%- with { 'item': childItem } -%}{{ block('renderItem') }}{% endwith %}
+                    {%- with { 'item': childItem, 'level': (level + 1) } -%}{{ block('renderItem') }}{% endwith %}
                 {% endfor %}
             </ol>
         {% endif %}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

They level was not increasing for each item that's why on some items we did not see the ADD button because:

```twig
{%- if 'add' in node.actions and node.addNodes|length > 0 and (def.maxDepth == 0 or level < def.maxDepth) -%}
```