### PR TITLE
fix: version tag from rawData

### DIFF
--- a/src/Entity/Revision.php
+++ b/src/Entity/Revision.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use EMS\CommonBundle\Common\ArrayHelper\RecursiveMapper;
-use EMS\CommonBundle\Common\Standard\DateTime;
+use EMS\CommonBundle\Common\Standard\Type;
 use EMS\CoreBundle\Core\Revision\RawDataTransformer;
 use EMS\CoreBundle\Exception\NotLockedException;
 use EMS\CoreBundle\Service\Mapping;
@@ -1228,9 +1228,8 @@ class Revision implements EntityInterface
             $versionId = isset($this->rawData['_version_uuid']) ? Uuid::fromString($this->rawData['_version_uuid']) : Uuid::uuid4();
             $this->setVersionId($versionId);
         }
-        if (null === $this->getVersionTag()) {
-            $this->setVersionTagDefault();
-        }
+
+        $this->setVersionTag($this->rawData[Mapping::VERSION_TAG] ?? $this->getVersionTagDefault());
 
         if (null === $this->getVersionDate('from') && null === $this->getVersionDate('to')) {
             if ($this->hasOuuid()) {
@@ -1246,7 +1245,7 @@ class Revision implements EntityInterface
         $this->versionUuid = $versionUuid;
     }
 
-    private function setVersionTagDefault(): void
+    private function getVersionTagDefault(): string
     {
         $versionTags = $this->contentType ? $this->contentType->getVersionTags() : [];
 
@@ -1254,7 +1253,7 @@ class Revision implements EntityInterface
             throw new \RuntimeException(\sprintf('No version tags found for contentType %s (use hasVersionTags)', $this->getContentTypeName()));
         }
 
-        $this->setVersionTag($versionTags[0]);
+        return Type::string($versionTags[0]);
     }
 
     public function setVersionTag(string $versionTag): void

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -1805,6 +1805,8 @@ class DataService
                 return $revision;
             }
 
+            $this->setMetaFields($newDraft);
+
             $newDraft->setStartTime($now);
             $revision->setEndTime($now);
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Setting meta fields on a revision should first look at the rawData for setting the version tag (Major/Minor,...). Because when we migrate only the rawData is set on the revision. Otherwise all revision will become the default versionTag.

On replaceData we should also call setMetaFields for updating incorrect versionTags from the api.

Plus EMS\CommonBundle\Common\Standard\DateTime was unused on Revision entity