### PR TITLE
fix: autowire controllers (for now)

### DIFF
--- a/src/Resources/config/controllers.xml
+++ b/src/Resources/config/controllers.xml
@@ -5,6 +5,8 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults autowire="true"/>
+
         <service id="EMS\CoreBundle\Controller\DashboardController" public="true">
             <argument type="service" id="ems_core.core_revision_task.task_manager" />
             <argument type="service" id="ems.dashboard.manager" />


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Because the controllers still use the container. Example getDoctrine() (60 search hits).

Commit that removed the autowire: https://github.com/ems-project/EMSCoreBundle/commit/2e0afddf37d13df8b9f307854a5b8f5af84dd35b#diff-7619d7a96fa2111a0a538186bc1a6a02bf99c582201cfabdd3b39b0af2227a57

Info:
https://symfony.com/doc/current/service_container.html#the-autowire-option
https://symfony.com/doc/current/controller/service.html#alternatives-to-base-controller-methods

Currently the old way of defining a search id on a datalink field is broken:

```
Error:
Call to a member function has() on null

  at vendor/symfony/framework-bundle/Controller/ControllerTrait.php:348
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->getDoctrine()
     (vendor/elasticms/core-bundle/src/Controller/ElasticsearchController.php:362)
  at EMS\CoreBundle\Controller\ElasticsearchController->deprecatedSearchApiAction()
     (vendor/elasticms/core-bundle/src/Controller/Search/QuerySearchController.php:57)
  at EMS\CoreBundle\Controller\Search\QuerySearchController->__invoke()
     (vendor/symfony/http-kernel/HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:47)
```
