### PR TITLE
fix: UploadedFileController not defined in controllers.xml

### DIFF
--- a/src/Resources/config/controllers.xml
+++ b/src/Resources/config/controllers.xml
@@ -308,5 +308,9 @@
             <argument type="service" id="ems.service.file" />
             <argument type="service" id="ems.logger" />
         </service>
+        <service id="EMS\CoreBundle\Controller\UploadedFileController" public="true">
+            <argument type="service" id="ems.logger" />
+            <argument type="service" id="ems.service.file" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

In the past it was loaded because of the prototype, which was not okay:
https://github.com/ems-project/EMSCoreBundle/commit/2e0afddf37d13df8b9f307854a5b8f5af84dd35b#diff-7619d7a96fa2111a0a538186bc1a6a02bf99c582201cfabdd3b39b0af2227a57

Error:
The controller for URI "/publisher/uploaded-file/" is not callable: Controller "EMS\CoreBundle\Controller\UploadedFileController" has required constructor arguments and does not exist in the container. Did you forget to define the controller as a service?