### PR TITLE
fix: api route file upload

### DIFF
--- a/src/Controller/ContentManagement/FileController.php
+++ b/src/Controller/ContentManagement/FileController.php
@@ -126,10 +126,7 @@ class FileController extends AbstractController
         ]);
     }
 
-    /**
-     * @param bool $apiRoute
-     */
-    public function uploadChunkAction(?string $sha1, ?string $hash, $apiRoute, Request $request): Response
+    public function uploadChunkAction(?string $sha1, ?string $hash, bool $apiRoute, Request $request): Response
     {
         if (null !== $sha1) {
             $hash = $sha1;

--- a/src/Resources/config/routing/api/file.xml
+++ b/src/Resources/config/routing/api/file.xml
@@ -13,25 +13,25 @@
     <route id="file.api.init-upload" path="/init-upload/{sha1}/{size}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::initUploadFileAction</default>
         <default key="_format">json</default>
-        <default key="true">true</default>
+        <default key="apiRoute"><bool>true</bool></default>
     </route>
     <route id="emsco_file_api_init_upload" path="/init-upload" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::initUploadFileAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">true</default>
+        <default key="apiRoute"><bool>true</bool></default>
         <default key="sha1" xsi:nil="true"/>
         <default key="size" xsi:nil="true"/>
     </route>
     <route id="file.api.uploadchunk" path="/upload-chunk/{sha1}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::uploadChunkAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">false</default>
+        <default key="apiRoute"><bool>true</bool></default>
         <default key="hash" xsi:nil="true"/>
     </route>
     <route id="emsco_file_api_chunk_upload" path="/chunk/{hash}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::uploadChunkAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">false</default>
+        <default key="apiRoute"><bool>true</bool></default>
         <default key="sha1" xsi:nil="true"/>
     </route>
     <route id="ems_api_image_upload_url" path="/" methods="POST">

--- a/src/Resources/config/routing/data/file.xml
+++ b/src/Resources/config/routing/data/file.xml
@@ -27,25 +27,25 @@
     <route id="file.init-upload" path="/init-upload/{sha1}/{size}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::initUploadFileAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">false</default>
+        <default key="apiRoute"><bool>false</bool></default>
     </route>
     <route id="emsco_file_data_init_upload" path="/init-upload" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::initUploadFileAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">false</default>
+        <default key="apiRoute"><bool>false</bool></default>
         <default key="sha1" xsi:nil="true"/>
         <default key="size" xsi:nil="true"/>
     </route>
     <route id="file.uploadchunk" path="/upload-chunk/{sha1}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::uploadChunkAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">false</default>
+        <default key="apiRoute"><bool>false</bool></default>
         <default key="hash" xsi:nil="true"/>
     </route>
     <route id="emsco_file_data_chunk_upload" path="/chunk/{hash}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::uploadChunkAction</default>
         <default key="_format">json</default>
-        <default key="apiRoute">false</default>
+        <default key="apiRoute"><bool>false</bool></default>
         <default key="sha1" xsi:nil="true"/>
     </route>
 </routes>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The file upload in web elasticms was using the api chunk, because the on init upload the route parameter $apiRoute was a string "false". 