### PR TITLE
fix: prefix file on public download route

### DIFF
--- a/src/Resources/config/routing/public.xml
+++ b/src/Resources/config/routing/public.xml
@@ -13,7 +13,7 @@
         <default key="public">1</default>
         <default key="_download">0</default>
     </route>
-    <route id="ems_file_download_public" path="/{sha1}" methods="GET HEAD">
+    <route id="ems_file_download_public" path="/file/{sha1}" methods="GET HEAD">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::downloadFileAction</default>
     </route>
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

After refactor the /file got removed. The common httpStorage uses this:

https://github.com/ems-project/EMSCommonBundle/blob/a80ace52316a539f387d6c8b89445d6c9c6efacf/src/Storage/Factory/HttpFactory.php#L67