### PR TITLE
fix: handle case where AssetFieldType is not mandatory

### DIFF
--- a/src/Form/DataField/AssetFieldType.php
+++ b/src/Form/DataField/AssetFieldType.php
@@ -165,7 +165,7 @@ class AssetFieldType extends DataFieldType
         $rawData = [];
         foreach ($data as $fileInfo) {
             if ((empty($fileInfo) || empty($fileInfo['sha1']))) {
-                if ($fieldType->getRestrictionOptions()['mandatory']) {
+                if (isset($fieldType->getRestrictionOptions()['mandatory']) && $fieldType->getRestrictionOptions()['mandatory']) {
                     $dataField->addMessage('This entry is required');
                 }
             } elseif (!$this->fileService->head($fileInfo['sha1'])) {

--- a/src/Form/DataField/AssetFieldType.php
+++ b/src/Form/DataField/AssetFieldType.php
@@ -165,7 +165,8 @@ class AssetFieldType extends DataFieldType
         $rawData = [];
         foreach ($data as $fileInfo) {
             if ((empty($fileInfo) || empty($fileInfo['sha1']))) {
-                if (isset($fieldType->getRestrictionOptions()['mandatory']) && $fieldType->getRestrictionOptions()['mandatory']) {
+                $restrictionOptions = $fieldType->getRestrictionOptions();
+                if (isset($restrictionOptions['mandatory']) && $restrictionOptions['mandatory']) {
                     $dataField->addMessage('This entry is required');
                 }
             } elseif (!$this->fileService->head($fileInfo['sha1'])) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Exception is thrown when the file is not mandatory