### PR TITLE
fix: only a DataFieldType's message if it's not possible to convert

### DIFF
--- a/src/Form/DataField/DateTimeFieldType.php
+++ b/src/Form/DataField/DateTimeFieldType.php
@@ -6,7 +6,6 @@ namespace EMS\CoreBundle\Form\DataField;
 
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
-use EMS\CoreBundle\Exception\DataFormatException;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -145,7 +144,10 @@ class DateTimeFieldType extends DataFieldType
         $dateTime = \DateTimeImmutable::createFromFormat(\DateTimeImmutable::ATOM, $value);
 
         if (false === $dateTime) {
-            throw new DataFormatException(\sprintf('Invalid parse format %s or ATOM for date string: %s', $parseFormat, $value));
+            $dataField = parent::reverseViewTransform($value, $fieldType);
+            $dataField->addMessage(\sprintf('Invalid parse format %s or ATOM for date string: %s', $parseFormat, $value));
+
+            return $dataField;
         }
 
         return parent::reverseViewTransform($dateTime->format(\DateTimeImmutable::ATOM), $fieldType);


### PR DESCRIPTION
a datetime string (not throwing an error)

|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

