### PR TITLE
fix: method get for json-update via ems interface

### DIFF
--- a/src/Resources/config/routing/content-type.xml
+++ b/src/Resources/config/routing/content-type.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="emsco_contenttype_update_from_json" path="/json-update/{contentType}" methods="POST">
+    <route id="emsco_contenttype_update_from_json" path="/json-update/{contentType}" methods="GET POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\ContentTypeController:updateFromJsonAction</default>
         <default key="_format">html</default>
     </route>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

We can not update a content type from the web interface: 

 Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException: "No route found for "GET /content-type/json-update/26": Method Not Allowed (Allow: POST)"

