### PR TITLE
fix: data links default behavior

### DIFF
--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -353,8 +353,13 @@ class ElasticsearchController extends AbstractController
 
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
-        $searchRepository = $em->getRepository('EMSCoreBundle:Form\Search');
-        $search = $searchRepository->findOneBy(['id' => $searchId]);
+
+        $search = null;
+        if ($searchId) {
+            $searchRepository = $em->getRepository('EMSCoreBundle:Form\Search');
+            $search = $searchRepository->findOneBy(['id' => $searchId]);
+        }
+
         if (!$search instanceof Search) {
             $search = $this->searchService->getDefaultSearch($contentTypes);
         }

--- a/src/Controller/Search/QuerySearchController.php
+++ b/src/Controller/Search/QuerySearchController.php
@@ -33,8 +33,7 @@ final class QuerySearchController extends AbstractController
 
         if ($dataLinks->isQuerySearch()) {
             $this->querySearchService->querySearchDataLinks($dataLinks);
-        }
-        if ($dataLinks->isSearch()) {
+        } elseif (!$dataLinks->hasItems()) {
             $this->elasticsearchController->deprecatedSearchApiAction($request, $dataLinks);
         }
 

--- a/src/Core/Document/DataLinks.php
+++ b/src/Core/Document/DataLinks.php
@@ -148,6 +148,11 @@ final class DataLinks
         return self::SIZE;
     }
 
+    public function hasItems(): bool
+    {
+        return \count($this->items) > 0;
+    }
+
     public function hasReferrerDocument(): bool
     {
         return null !== $this->referrerDocument;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

When no search or query search and no custom view we should still search offcourse