### PR TITLE
fix: pick from server broken

### DIFF
--- a/src/Controller/UploadedFileWysiwygController.php
+++ b/src/Controller/UploadedFileWysiwygController.php
@@ -74,6 +74,8 @@ final class UploadedFileWysiwygController extends AbstractController
     }
 
     /**
+     * Changing the access modifier from protected to public on the generateUrl
+     *
      * @param array<string, mixed> $parameters
      */
     public function generateUrl(string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string

--- a/src/Controller/UploadedFileWysiwygController.php
+++ b/src/Controller/UploadedFileWysiwygController.php
@@ -74,7 +74,7 @@ final class UploadedFileWysiwygController extends AbstractController
     }
 
     /**
-     * Changing the access modifier from protected to public on the generateUrl
+     * Changing the access modifier from protected to public on the generateUrl.
      *
      * @param array<string, mixed> $parameters
      */

--- a/src/Controller/UploadedFileWysiwygController.php
+++ b/src/Controller/UploadedFileWysiwygController.php
@@ -22,6 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class UploadedFileWysiwygController extends AbstractController
 {
@@ -70,6 +71,14 @@ final class UploadedFileWysiwygController extends AbstractController
                 'form' => $form->createView(),
             ])
             ->getResponse();
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function generateUrl(string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
+    {
+        return parent::generateUrl($route, $parameters, $referenceType);
     }
 
     private function initTable(): EntityTable


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

This is a rollback on #1047, it was not useless because now we get this php error:

> Uncaught Error: Call to protected method Symfony\Bundle\FrameworkBundle\Controller\AbstractController::generateUrl() from context 'EMS\CoreBundle\Form\Data\TableColumn'
> Uncaught PHP Exception Error: "Call to protected method Symfony\Bundle\FrameworkBundle\Controller\AbstractController::generateUrl() from context 'EMS\CoreBundle\Form\Data\TableColumn'" at C:\dev\symfony\smals-elasticms\vendor\elasticms\core-bundle\src\Controller\UploadedFileWysiwygController.php line 86

We forward the controller with use into a callback function, this will throw an php exception because it's a protected method, thats way we need to overwrite it in the controller. This way we make it public and available in the callback.

```php
$table = new EntityTable($this->fileService, $this->generateUrl('ems_core_uploaded_file_wysiwyg_ajax'), ['available' => false]);
        $controller = $this;
        $table->addColumn('uploaded-file.index.column.name', 'name')
            ->addHtmlAttribute('data-url', function (UploadedAsset $data) {
                return EMSLink::EMSLINK_ASSET_PREFIX.$data->getSha1().'?name='.$data->getName().'&type='.$data->getType();
            })
            ->addHtmlAttribute('data-json', function (UploadedAsset $data) use ($controller) {
                $json = $data->getData();
                $json = \array_merge($json, [
                    'preview_url' => $controller->generateUrl('ems_asset_processor', [
                        'hash' => $data->getSha1(),
                        'processor' => 'preview',
                        'type' => $data->getType(),
                        'name' => $data->getName(),
                    ]),
                    'view_url' => $controller->generateUrl('ems.file.view', [
                        'sha1' => $data->getSha1(),
                        'type' => $data->getType(),
                        'name' => $data->getName(),
                    ]),
                ]);

                return Json::encode($json);
            })
```


#1091 