### PR TITLE
fix: api auth broken & channels

### DIFF
--- a/src/Controller/AuthTokenController.php
+++ b/src/Controller/AuthTokenController.php
@@ -12,17 +12,22 @@ class AuthTokenController
 {
     private Authenticator $authenticator;
     private Environment $twig;
+    private string $firewallName;
 
-    public function __construct(Authenticator $authenticator, Environment $twig)
-    {
+    public function __construct(
+        Authenticator $authenticator,
+        Environment $twig,
+        string $firewallName
+    ) {
         $this->authenticator = $authenticator;
         $this->twig = $twig;
+        $this->firewallName = $firewallName;
     }
 
     public function postAuthTokensAction(Request $request): Response
     {
         try {
-            $token = Credentials::usernamePasswordToken($request, Credentials::DEFAULT_PROVIDER_KEY);
+            $token = Credentials::usernamePasswordToken($request, $this->firewallName);
             $authToken = $this->authenticator->generateAuthToken($token);
         } catch (\Exception $exception) {
             return $this->authenticator->failedResponse();

--- a/src/Resources/config/controllers.xml
+++ b/src/Resources/config/controllers.xml
@@ -98,6 +98,7 @@
         <service id="EMS\CoreBundle\Controller\AuthTokenController" public="true">
             <argument type="service" id="ems.security.authenticator" />
             <argument type="service" id="twig" />
+            <argument>%ems_core.security.firewall.core%</argument>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\Form\SubmissionController" public="true">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -39,6 +39,7 @@
             <argument type="service" id="EMS\ClientHelperBundle\Contracts\Environment\EnvironmentHelperInterface"/>
             <argument type="service" id="logger"/>
             <argument type="service" id="ems.service.index"/>
+            <argument>%ems_core.security.firewall.core%</argument>
         </service>
         <service id="ems.service.datatable" alias="EMS\CoreBundle\Service\DatatableService"/>
         <service id="EMS\CoreBundle\Service\DatatableService">

--- a/src/Security/Credentials.php
+++ b/src/Security/Credentials.php
@@ -7,8 +7,6 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class Credentials
 {
-    public const DEFAULT_PROVIDER_KEY = 'main';
-
     private function __construct()
     {
     }

--- a/src/Service/Channel/ChannelRegistrar.php
+++ b/src/Service/Channel/ChannelRegistrar.php
@@ -18,15 +18,22 @@ final class ChannelRegistrar
     private EnvironmentHelperInterface $environmentHelper;
     private LoggerInterface $logger;
     private IndexService $indexService;
+    private string $firewallName;
 
     public const EMSCO_CHANNEL_PATH_REGEX = '/^(\\/index\\.php)?\\/channel\\/(?P<channel>([a-z\\-0-9_]+))(\\/)?/';
 
-    public function __construct(ChannelRepository $channelRepository, EnvironmentHelperInterface $environmentHelper, LoggerInterface $logger, IndexService $indexService)
-    {
+    public function __construct(
+        ChannelRepository $channelRepository,
+        EnvironmentHelperInterface $environmentHelper,
+        LoggerInterface $logger,
+        IndexService $indexService,
+        string $firewallName
+    ) {
         $this->channelRepository = $channelRepository;
         $this->environmentHelper = $environmentHelper;
         $this->logger = $logger;
         $this->indexService = $indexService;
+        $this->firewallName = $firewallName;
     }
 
     public function register(Request $request): void
@@ -76,6 +83,6 @@ final class ChannelRegistrar
 
     private function isAnonymousUser(Request $request): bool
     {
-        return null === $request->getSession()->get('_security_main');
+        return null === $request->getSession()->get('_security_'.$this->firewallName);
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

We should use the parameter "ems_core.security.firewall.core" instead of "main"
The channel registrar should also use this parameter