### PR TITLE
feat: unpublish command

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -121,20 +121,49 @@ Options:
 ### Align
 
 ```bash
-Usage:
-  emsco:environment:align [options] [--] <source> <target>
-
-Arguments:
-  source                               Environment source name
-  target                               Environment target name
-
-Options:
+Description:
+  Align an environment from another one                                                                               
+                                                                                                                      
+Usage:                                                                                                                
+  emsco:environment:align [options] [--] <source> <target>                                                            
+                                                                                                                      
+Arguments:                                                                                                            
+  source                               Environment source name                                                        
+  target                               Environment target name                                                        
+                                                                                                                      
+Options:                                                                                                              
+      --snapshot                       If set, the target environment will be tagged as a snapshot after the alignment
+      --force                          If set, the task will be performed (protection)
       --scroll-size=SCROLL-SIZE        Size of the elasticsearch scroll request
       --scroll-timeout=SCROLL-TIMEOUT  Time to migrate "scrollSize" items i.e. 30s or 2m
       --search-query[=SEARCH-QUERY]    Query used to find elasticsearch records to import [default: "{}"]
-      --force                          If set, the task will be performed (protection)
-      --snapshot                       If set, the target environment will be tagged as a snapshot after the alignment
       --user=USER                      Lock user [default: "SYSTEM_ALIGN"]
+      --dry-run                        Dry run
+```
+
+### Unpublish
+
+You can not unpublish:
+- revisions from their default environment, you should use '**emsco:revision:archive**' for this.
+- revision if it's the only environment. This can happen when the revision is archived in the default environment.
+
+```bash
+Description:
+  Unpublish revision from an environment
+
+Usage:
+  emsco:environment:unpublish [options] [--] <environment>
+
+Arguments:
+  environment                          Environment name
+
+Options:
+      --force                          If set, the task will be performed (protection)
+      --scroll-size=SCROLL-SIZE        Size of the elasticsearch scroll request
+      --scroll-timeout=SCROLL-TIMEOUT  Time to migrate "scrollSize" items i.e. 30s or 2m
+      --search-query[=SEARCH-QUERY]    Query used to find elasticsearch records to import [default: "{}"]
+      --user=USER                      Lock user [default: "SYSTEM_ALIGN"]
+      --dry-run                        Dry run
 ```
 
 ## Revision

--- a/src/Command/Environment/AbstractEnvironmentCommand.php
+++ b/src/Command/Environment/AbstractEnvironmentCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Command\Environment;
+
+use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CoreBundle\Core\Revision\Search\RevisionSearcher;
+use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Service\EnvironmentService;
+use EMS\CoreBundle\Service\PublishService;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class AbstractEnvironmentCommand extends AbstractCommand
+{
+    protected RevisionSearcher $revisionSearcher;
+    protected EnvironmentService $environmentService;
+    protected PublishService $publishService;
+
+    protected string $searchQuery = '{}';
+
+    public const OPTION_SCROLL_SIZE = 'scroll-size';
+    public const OPTION_SCROLL_TIMEOUT = 'scroll-timeout';
+    public const OPTION_SEARCH_QUERY = 'search-query';
+
+    public function __construct(
+        RevisionSearcher $revisionSearcher,
+        EnvironmentService $environmentService,
+        PublishService $publishService
+    ) {
+        parent::__construct();
+        $this->revisionSearcher = $revisionSearcher;
+        $this->environmentService = $environmentService;
+        $this->publishService = $publishService;
+    }
+
+    protected function configureRevisionSearcher(): void
+    {
+        $this
+            ->addOption(self::OPTION_SCROLL_SIZE, null, InputOption::VALUE_REQUIRED, 'Size of the elasticsearch scroll request')
+            ->addOption(self::OPTION_SCROLL_TIMEOUT, null, InputOption::VALUE_REQUIRED, 'Time to migrate "scrollSize" items i.e. 30s or 2m')
+            ->addOption(self::OPTION_SEARCH_QUERY, null, InputOption::VALUE_OPTIONAL, 'Query used to find elasticsearch records to import', '{}')
+        ;
+    }
+
+    protected function initializeRevisionSearcher(): void
+    {
+        if ($scrollSize = $this->getOptionIntNull(self::OPTION_SCROLL_SIZE)) {
+            $this->revisionSearcher->setSize($scrollSize);
+        }
+        if ($scrollTimeout = $this->getOptionStringNull(self::OPTION_SCROLL_TIMEOUT)) {
+            $this->revisionSearcher->setTimeout($scrollTimeout);
+        }
+
+        $this->searchQuery = $this->getOptionString(self::OPTION_SEARCH_QUERY);
+    }
+
+    protected function choiceEnvironment(string $argument, string $question): Environment
+    {
+        $environmentNames = $this->environmentService->getEnvironmentNames();
+
+        $this->choiceArgumentString($argument, $question, $environmentNames);
+
+        return $this->environmentService->findByName($this->getArgumentString($argument));
+    }
+}

--- a/src/Command/Environment/AbstractEnvironmentCommand.php
+++ b/src/Command/Environment/AbstractEnvironmentCommand.php
@@ -9,19 +9,27 @@ use EMS\CoreBundle\Core\Revision\Search\RevisionSearcher;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\PublishService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractEnvironmentCommand extends AbstractCommand
 {
     protected RevisionSearcher $revisionSearcher;
     protected EnvironmentService $environmentService;
     protected PublishService $publishService;
+    protected ?LoggerInterface $logger = null;
 
     protected string $searchQuery = '{}';
+    protected string $lockUser = 'SYSTEM_ALIGN';
 
     public const OPTION_SCROLL_SIZE = 'scroll-size';
     public const OPTION_SCROLL_TIMEOUT = 'scroll-timeout';
     public const OPTION_SEARCH_QUERY = 'search-query';
+    public const OPTION_USER = 'user';
+    public const OPTION_FORCE = 'force';
 
     public function __construct(
         RevisionSearcher $revisionSearcher,
@@ -34,16 +42,28 @@ abstract class AbstractEnvironmentCommand extends AbstractCommand
         $this->publishService = $publishService;
     }
 
+    protected function configureForceProtection(): void
+    {
+        $this->addOption(self::OPTION_FORCE, null, InputOption::VALUE_NONE, 'If set, the task will be performed (protection)');
+    }
+
     protected function configureRevisionSearcher(): void
     {
         $this
             ->addOption(self::OPTION_SCROLL_SIZE, null, InputOption::VALUE_REQUIRED, 'Size of the elasticsearch scroll request')
             ->addOption(self::OPTION_SCROLL_TIMEOUT, null, InputOption::VALUE_REQUIRED, 'Time to migrate "scrollSize" items i.e. 30s or 2m')
             ->addOption(self::OPTION_SEARCH_QUERY, null, InputOption::VALUE_OPTIONAL, 'Query used to find elasticsearch records to import', '{}')
+            ->addOption(self::OPTION_USER, null, InputOption::VALUE_REQUIRED, 'Lock user', $this->lockUser)
         ;
     }
 
-    protected function initializeRevisionSearcher(): void
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+        $this->logger = new ConsoleLogger($output);
+    }
+
+    protected function initializeRevisionSearcher(string $lockUser): void
     {
         if ($scrollSize = $this->getOptionIntNull(self::OPTION_SCROLL_SIZE)) {
             $this->revisionSearcher->setSize($scrollSize);
@@ -53,6 +73,7 @@ abstract class AbstractEnvironmentCommand extends AbstractCommand
         }
 
         $this->searchQuery = $this->getOptionString(self::OPTION_SEARCH_QUERY);
+        $this->lockUser = $this->getOptionString(self::OPTION_USER, $lockUser);
     }
 
     protected function choiceEnvironment(string $argument, string $question): Environment
@@ -62,5 +83,16 @@ abstract class AbstractEnvironmentCommand extends AbstractCommand
         $this->choiceArgumentString($argument, $question, $environmentNames);
 
         return $this->environmentService->findByName($this->getArgumentString($argument));
+    }
+
+    protected function forceProtection(InputInterface $input): bool
+    {
+        if (!$input->getOption(self::OPTION_FORCE)) {
+            $this->io->error('Has protection, the force option is mandatory.');
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Command/Environment/AbstractEnvironmentCommand.php
+++ b/src/Command/Environment/AbstractEnvironmentCommand.php
@@ -24,12 +24,14 @@ abstract class AbstractEnvironmentCommand extends AbstractCommand
 
     protected string $searchQuery = '{}';
     protected string $lockUser = 'SYSTEM_ALIGN';
+    protected bool $dryRun = false;
 
     public const OPTION_SCROLL_SIZE = 'scroll-size';
     public const OPTION_SCROLL_TIMEOUT = 'scroll-timeout';
     public const OPTION_SEARCH_QUERY = 'search-query';
     public const OPTION_USER = 'user';
     public const OPTION_FORCE = 'force';
+    public const OPTION_DRY_RUN = 'dry-run';
 
     public function __construct(
         RevisionSearcher $revisionSearcher,
@@ -54,6 +56,7 @@ abstract class AbstractEnvironmentCommand extends AbstractCommand
             ->addOption(self::OPTION_SCROLL_TIMEOUT, null, InputOption::VALUE_REQUIRED, 'Time to migrate "scrollSize" items i.e. 30s or 2m')
             ->addOption(self::OPTION_SEARCH_QUERY, null, InputOption::VALUE_OPTIONAL, 'Query used to find elasticsearch records to import', '{}')
             ->addOption(self::OPTION_USER, null, InputOption::VALUE_REQUIRED, 'Lock user', $this->lockUser)
+            ->addOption(self::OPTION_DRY_RUN, '', InputOption::VALUE_NONE, 'Dry run')
         ;
     }
 
@@ -74,6 +77,7 @@ abstract class AbstractEnvironmentCommand extends AbstractCommand
 
         $this->searchQuery = $this->getOptionString(self::OPTION_SEARCH_QUERY);
         $this->lockUser = $this->getOptionString(self::OPTION_USER, $lockUser);
+        $this->dryRun = $this->getOptionBool(self::OPTION_DRY_RUN);
     }
 
     protected function choiceEnvironment(string $argument, string $question): Environment

--- a/src/Command/Environment/AlignCommand.php
+++ b/src/Command/Environment/AlignCommand.php
@@ -62,6 +62,12 @@ class AlignCommand extends AbstractEnvironmentCommand
 
         $this->io->note(\sprintf('The source environment contains %s elements, start aligning environments...', $search->getTotal()));
 
+        if ($this->dryRun) {
+            $this->io->success('Dry run finished');
+
+            return self::EXECUTE_SUCCESS;
+        }
+
         $deletedRevision = 0;
         $alreadyAligned = 0;
         $targetIsPreviewEnvironment = [];

--- a/src/Command/Environment/UnpublishCommand.php
+++ b/src/Command/Environment/UnpublishCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Command\Environment;
+
+use EMS\CoreBundle\Commands;
+use EMS\CoreBundle\Entity\Environment;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class UnpublishCommand extends AbstractEnvironmentCommand
+{
+    private Environment $environment;
+
+    public const ARGUMENT_ENVIRONMENT = 'environment';
+
+    protected static $defaultName = Commands::ENVIRONMENT_UNPUBLISH;
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Unpbulish revision from an environment')
+            ->addArgument(self::ARGUMENT_ENVIRONMENT, InputArgument::REQUIRED, 'Environment name')
+        ;
+
+        $this->configureRevisionSearcher();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+        $this->io->title('EMS - Environment - Unpublish');
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        $this->environment = $this->choiceEnvironment(self::ARGUMENT_ENVIRONMENT, 'Select an existing environment');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->success($this->environment->getName());
+
+        return self::EXECUTE_SUCCESS;
+    }
+}

--- a/src/Command/Environment/UnpublishCommand.php
+++ b/src/Command/Environment/UnpublishCommand.php
@@ -13,18 +13,24 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class UnpublishCommand extends AbstractEnvironmentCommand
 {
     private Environment $environment;
+    private int $counter = 0;
+    /** @var array<string, int> */
+    private array $warnings = [];
 
     public const ARGUMENT_ENVIRONMENT = 'environment';
+
+    private const LOCK_USER = 'SYSTEM_UNPUBLISH';
 
     protected static $defaultName = Commands::ENVIRONMENT_UNPUBLISH;
 
     protected function configure(): void
     {
         $this
-            ->setDescription('Unpbulish revision from an environment')
+            ->setDescription('Unpublish revision from an environment')
             ->addArgument(self::ARGUMENT_ENVIRONMENT, InputArgument::REQUIRED, 'Environment name')
         ;
 
+        $this->configureForceProtection();
         $this->configureRevisionSearcher();
     }
 
@@ -32,6 +38,8 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
     {
         parent::initialize($input, $output);
         $this->io->title('EMS - Environment - Unpublish');
+
+        $this->initializeRevisionSearcher(self::LOCK_USER);
     }
 
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -41,7 +49,41 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->io->success($this->environment->getName());
+        if (!$this->forceProtection($input)) {
+            return self::EXECUTE_ERROR;
+        }
+
+        $search = $this->revisionSearcher->create($this->environment, $this->searchQuery);
+        $bulkSize = $this->revisionSearcher->getSize();
+
+        $this->io->note(\sprintf('Found "%d" revisions in "%s" environment', $search->getTotal(), $this->environment));
+
+        $this->io->progressStart($search->getTotal());
+        foreach ($this->revisionSearcher->search($this->environment, $search) as $revisions) {
+            $this->revisionSearcher->lock($revisions, $this->lockUser);
+            $this->publishService->bulkStart($bulkSize, $this->logger);
+
+            foreach ($revisions->transaction() as $revision) {
+                $this->io->progressAdvance();
+
+                try {
+                    $this->publishService->bulkUnpublish($revision, $this->environment);
+                    ++$this->counter;
+                } catch (\LogicException $e) {
+                    $this->warnings[$e->getMessage()] = ($this->warnings[$e->getMessage()] ?? 0) + 1;
+                }
+            }
+
+            $this->publishService->bulkFinished();
+            $this->revisionSearcher->unlock($revisions);
+        }
+        $this->io->progressFinish();
+
+        foreach ($this->warnings as $warning => $warningCounter) {
+            $this->io->warning(\sprintf('%s : %d', $warning, $warningCounter));
+        }
+
+        $this->io->success(\sprintf('Unpublished "%d" documents from "%s"', $this->counter, $this->environment));
 
         return self::EXECUTE_SUCCESS;
     }

--- a/src/Command/Environment/UnpublishCommand.php
+++ b/src/Command/Environment/UnpublishCommand.php
@@ -58,6 +58,12 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
 
         $this->io->note(\sprintf('Found "%d" revisions in "%s" environment', $search->getTotal(), $this->environment));
 
+        if ($this->dryRun) {
+            $this->io->success('Dry run finished');
+
+            return self::EXECUTE_SUCCESS;
+        }
+
         $this->io->progressStart($search->getTotal());
         foreach ($this->revisionSearcher->search($this->environment, $search) as $revisions) {
             $this->revisionSearcher->lock($revisions, $this->lockUser);

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -9,6 +9,7 @@ final class Commands
     public const CONTENT_TYPE_TRANSFORM = 'emsco:contenttype:transform';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';
+    public const ENVIRONMENT_UNPUBLISH = 'emsco:environment:unpublish';
 
     public const RELEASE_PUBLISH = 'emsco:release:publish';
     public const RELEASE_CREATE = 'emsco:release:create';

--- a/src/Core/Revision/Search/RevisionSearcher.php
+++ b/src/Core/Revision/Search/RevisionSearcher.php
@@ -74,7 +74,7 @@ final class RevisionSearcher
     /**
      * @return iterable|Revisions[]
      */
-    public function search(Environment $environment, RevisionSearch $search, ?string $lockBy = null, string $until = '+5 minutes'): iterable
+    public function search(Environment $environment, RevisionSearch $search): iterable
     {
         $config = $this->entityManager->getConnection()->getConfiguration();
         $logger = $config->getSQLLogger();

--- a/src/Elasticsearch/Bulker.php
+++ b/src/Elasticsearch/Bulker.php
@@ -78,6 +78,17 @@ class Bulker
         return $this;
     }
 
+    public function delete(string $contentType, string $index, string $ouuid): bool
+    {
+        $action = $this->createAction($contentType, $index, $ouuid);
+        $action->setOpType(Action::OP_TYPE_DELETE);
+
+        $this->bulk->addAction($action);
+        ++$this->counter;
+
+        return $this->send();
+    }
+
     public function index(string $contentType, string $ouuid, string $index, array &$body, bool $upsert = false): bool
     {
         if ($this->sign) {
@@ -90,13 +101,7 @@ class Bulker
             $body[Mapping::PUBLISHED_DATETIME_FIELD] = (new \DateTime())->format(\DateTimeInterface::ATOM);
         }
 
-        $action = new Action();
-        $action->setIndex($index);
-        $action->setId($ouuid);
-        $typePath = $this->mapping->getTypePath($contentType);
-        if ('.' !== $typePath) {
-            $action->setType($typePath);
-        }
+        $action = $this->createAction($contentType, $index, $ouuid);
 
         //@todo check this with a elastica 7
         $source = JSON::stringify($body, JSON_UNESCAPED_UNICODE); //elastica actions do not support fields named 'doc' or 'doc_as_upsert'
@@ -170,6 +175,19 @@ class Bulker
         }
 
         return true;
+    }
+
+    private function createAction(string $contentType, string $index, string $ouuid): Action
+    {
+        $action = new Action();
+        $action->setIndex($index);
+        $action->setId($ouuid);
+        $typePath = $this->mapping->getTypePath($contentType);
+        if ('.' !== $typePath) {
+            $action->setType($typePath);
+        }
+
+        return $action;
     }
 
     private function logResponse(ResponseSet $response): void

--- a/src/Repository/RevisionRepository.php
+++ b/src/Repository/RevisionRepository.php
@@ -121,6 +121,7 @@ class RevisionRepository extends EntityRepository
     {
         $qb = $this->createQueryBuilder('r');
         $qb
+            ->addSelect('ce, c, re')
             ->join('r.contentType', 'c')
             ->join('c.environment', 'ce')
             ->join('r.environments', 're')

--- a/src/Repository/RevisionRepository.php
+++ b/src/Repository/RevisionRepository.php
@@ -121,7 +121,7 @@ class RevisionRepository extends EntityRepository
     {
         $qb = $this->createQueryBuilder('r');
         $qb
-            ->addSelect('ce, c, re')
+            ->addSelect('ce, c')
             ->join('r.contentType', 'c')
             ->join('c.environment', 'ce')
             ->join('r.environments', 're')

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -20,11 +20,15 @@
         </service>
 
         <!-- EMS environment -->
-        <service id="ems.command.environment.align" class="EMS\CoreBundle\Command\Environment\AlignCommand">
+        <service id="ems_core.command_environment.abstract_environment_command" class="EMS\CoreBundle\Command\Environment\AbstractEnvironmentCommand" abstract="true">
             <argument type="service" id="ems_core.core_revision_search.revision_searcher" />
-            <argument type="service" id="logger" />
             <argument type="service" id="ems.service.environment" />
             <argument type="service" id="ems.service.publish" />
+        </service>
+        <service id="ems_core.command_environment.align_command" class="EMS\CoreBundle\Command\Environment\AlignCommand" parent="ems_core.command_environment.abstract_environment_command">
+            <tag name="console.command"/>
+        </service>
+        <service id="ems_core.command_environment.unpublish_command" class="EMS\CoreBundle\Command\Environment\UnpublishCommand" parent="ems_core.command_environment.abstract_environment_command">
             <tag name="console.command"/>
         </service>
 

--- a/src/Service/PublishService.php
+++ b/src/Service/PublishService.php
@@ -177,10 +177,16 @@ class PublishService
         $contentType = $revision->giveContentType();
 
         if ($contentType->giveEnvironment() === $environment) {
-            throw new \LogicException('Unpublish failed from default environment');
+            throw new \LogicException('Unpublish failed: is default environment');
         }
 
-        $revision->getEnvironments()->removeElement($environment);
+        $environments = $revision->getEnvironments();
+
+        if (1 === $environments->count()) {
+            throw new \LogicException('Unpublish failed: requires 1 environment');
+        }
+
+        $environments->removeElement($environment);
         $this->bulker->delete($contentType->getName(), $environment->getAlias(), $revision->getOuuid());
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

## Feature
> Feature request: make a unpublish command which can work with a search query and environment name.

## Info
Because the align command also does unpublish actions, created an AbstractEnvironment command. In the feature we could also easly add a publish command.

## Checks
- You can not unpublish revision from their default environment, you should use revision Archive for this.
- You can not unpublish revision if it's the only environment. This can happen when the revision is archived in the default environment.
