### PR TITLE
fix: load all from querysearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,6 @@
 		"phpcs": "php-cs-fixer fix",
 		"phpstan": "phpstan analyse --memory-limit 1G",
 		"phpunit": "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan"
+		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
 	},
 	"scripts": {
 		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse",
+		"phpstan": "phpstan analyse --memory-limit 1G",
 		"phpunit": "phpunit",
 		"phpall": "php-cs-fixer fix && phpunit && phpstan"
 	}

--- a/src/Form/Factory/ObjectChoiceListFactory.php
+++ b/src/Form/Factory/ObjectChoiceListFactory.php
@@ -34,16 +34,16 @@ class ObjectChoiceListFactory extends DefaultChoiceListFactory
     /**
      * instanciate a ObjectChoiceLoader (with the required services).
      */
-    public function createLoader($types = null, $loadAll = false, $circleOnly = false, bool $withWarning = true)
+    public function createLoader($types = null, $loadAll = false, $circleOnly = false, bool $withWarning = true, ?string $querySearchName = null)
     {
         if (null === $types || '' === $loadAll) {
-            if ($loadAll) {
+            if ($loadAll && null === $querySearchName) {
                 throw new PerformanceException('Try to load all objects of all content types');
             }
             $types = $this->contentTypes->getAllTypes();
         }
 
-        return new ObjectChoiceLoader($this->objectChoiceCacheService, $types, $loadAll, $circleOnly, $withWarning);
+        return new ObjectChoiceLoader($this->objectChoiceCacheService, $types, $loadAll, $circleOnly, $withWarning, $querySearchName);
     }
 
     /**

--- a/src/Form/Field/ObjectChoiceList.php
+++ b/src/Form/Field/ObjectChoiceList.php
@@ -18,13 +18,15 @@ class ObjectChoiceList implements ChoiceListInterface
     private $circleOnly;
     /** @var bool */
     private $withWarning;
+    private ?string $querySearchName;
 
     public function __construct(
         ObjectChoiceCacheService $objectChoiceCacheService,
         $types = false,
         bool $loadAll = false,
         bool $circleOnly = false,
-        bool $withWarning = true
+        bool $withWarning = true,
+        ?string $querySearchName = null
     ) {
         $this->objectChoiceCacheService = $objectChoiceCacheService;
         $this->choices = [];
@@ -32,6 +34,7 @@ class ObjectChoiceList implements ChoiceListInterface
         $this->loadAll = $loadAll;
         $this->circleOnly = $circleOnly;
         $this->withWarning = $withWarning;
+        $this->querySearchName = $querySearchName;
     }
 
     public function getTypes()

--- a/src/Form/Field/ObjectChoiceList.php
+++ b/src/Form/Field/ObjectChoiceList.php
@@ -104,7 +104,7 @@ class ObjectChoiceList implements ChoiceListInterface
     public function loadAll()
     {
         if ($this->loadAll) {
-            $this->objectChoiceCacheService->loadAll($this->choices, $this->types, $this->circleOnly, $this->withWarning);
+            $this->objectChoiceCacheService->loadAll($this->choices, $this->types, $this->circleOnly, $this->withWarning, $this->querySearchName);
         }
 
         return $this->choices;

--- a/src/Form/Field/ObjectChoiceList.php
+++ b/src/Form/Field/ObjectChoiceList.php
@@ -44,7 +44,7 @@ class ObjectChoiceList implements ChoiceListInterface
      */
     public function getChoices()
     {
-        $this->loadAll($this->types);
+        $this->loadAll();
 
         return $this->choices;
     }
@@ -98,10 +98,10 @@ class ObjectChoiceList implements ChoiceListInterface
         return \array_keys($this->choices);
     }
 
-    public function loadAll($types)
+    public function loadAll()
     {
         if ($this->loadAll) {
-            $this->objectChoiceCacheService->loadAll($this->choices, $types, $this->circleOnly, $this->withWarning);
+            $this->objectChoiceCacheService->loadAll($this->choices, $this->types, $this->circleOnly, $this->withWarning);
         }
 
         return $this->choices;

--- a/src/Form/Field/ObjectChoiceLoader.php
+++ b/src/Form/Field/ObjectChoiceLoader.php
@@ -15,9 +15,10 @@ class ObjectChoiceLoader implements ChoiceLoaderInterface
         $types,
         bool $loadAll,
         bool $circleOnly,
-        bool $withWarning
+        bool $withWarning,
+        ?string $querySearchName
     ) {
-        $this->objectChoiceList = new ObjectChoiceList($objectChoiceCacheService, $types, $loadAll, $circleOnly, $withWarning);
+        $this->objectChoiceList = new ObjectChoiceList($objectChoiceCacheService, $types, $loadAll, $circleOnly, $withWarning, $querySearchName);
     }
 
     /**

--- a/src/Form/Field/ObjectChoiceLoader.php
+++ b/src/Form/Field/ObjectChoiceLoader.php
@@ -33,7 +33,7 @@ class ObjectChoiceLoader implements ChoiceLoaderInterface
      */
     public function loadAll()
     {
-        return $this->objectChoiceList->loadAll($this->objectChoiceList->getTypes());
+        return $this->objectChoiceList->loadAll();
     }
 
     /**

--- a/src/Form/Field/ObjectPickerType.php
+++ b/src/Form/Field/ObjectPickerType.php
@@ -35,8 +35,12 @@ class ObjectPickerType extends Select2Type
                 $loadAll = $options->offsetGet('dynamicLoading') ? false : true;
                 $circleOnly = $options->offsetGet('circle-only');
                 $withWarning = $options->offsetGet('with_warning');
+                $querySearch = $options->offsetGet('querySearch');
+                if (!\is_string($querySearch) || 0 === \strlen($querySearch)) {
+                    $querySearch = null;
+                }
 
-                return $this->choiceListFactory->createLoader($options->offsetGet('type'), $loadAll, $circleOnly, $withWarning);
+                return $this->choiceListFactory->createLoader($options->offsetGet('type'), $loadAll, $circleOnly, $withWarning, $querySearch);
             },
             'choice_label' => function ($value, $key, $index) {
                 return $value->getLabel();

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -446,7 +446,7 @@ services:
             - { name: emsco.entity.service }
     ems.service.objectchoicecache:
         class: EMS\CoreBundle\Service\ObjectChoiceCacheService
-        arguments: ['@logger', '@ems.service.contenttype', '@security.authorization_checker', '@security.token_storage', '@ems_common.service.elastica']
+        arguments: ['@logger', '@ems.service.contenttype', '@security.authorization_checker', '@security.token_storage', '@ems_common.service.elastica', '@ems.service.query_search']
     ems.service.publish:
         class: EMS\CoreBundle\Service\PublishService
         arguments: ['@doctrine', '@security.authorization_checker', '@security.token_storage', '@ems.service.index', '@ems.service.mapping', '%ems_core.instance_id%', '@session', '@ems.service.contenttype', '@ems.service.environment', '@ems.service.data', '@ems.service.user', '@event_dispatcher', '@emsco.logger', '@emsco.logger.audit', '@ems.elasticsearch.bulker']

--- a/src/Service/ObjectChoiceCacheService.php
+++ b/src/Service/ObjectChoiceCacheService.php
@@ -56,6 +56,7 @@ class ObjectChoiceCacheService
 
             return;
         }
+        @\trigger_error('Using types and/or searchId in DataLink field is deprecated use a QuerySearch instead', E_USER_DEPRECATED);
 
         $token = $this->tokenStorage->getToken();
         if (!$token instanceof TokenInterface) {

--- a/src/Service/ObjectChoiceCacheService.php
+++ b/src/Service/ObjectChoiceCacheService.php
@@ -46,6 +46,7 @@ class ObjectChoiceCacheService
 
         $this->fullyLoaded = [];
         $this->cache = [];
+        $this->cachedQuerySearches = [];
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Solve an error if a datlink field type is using a query search with the dynamic loading not checked