### PR TITLE
fix: datalinks not showing selected

### DIFF
--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -343,8 +343,8 @@ class ElasticsearchController extends AbstractController
             $contentType = $this->contentTypeService->giveByName($emsLink->getContentType());
             $document = $this->searchService->getDocument($contentType, $emsLink->getOuuid());
 
-            $dataLinks->addDocument($document);
             $dataLinks->addContentTypes($contentType);
+            $dataLinks->addDocument($document);
 
             return;
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Only when not using QuerySearch, edit link is not showing the label.

![image](https://user-images.githubusercontent.com/10576303/177996757-b1717c1a-19d3-482c-b8b9-92fef4d20a3a.png)

ContentType should be added before the document, otherwise we can not resolve the labelField