### PR TITLE
fix: update referrers

### DIFF
--- a/src/Core/Revision/Json/JsonMenuNestedDefinition.php
+++ b/src/Core/Revision/Json/JsonMenuNestedDefinition.php
@@ -333,7 +333,7 @@ final class JsonMenuNestedDefinition
     }
 
     /**
-     * @param Collection<string, FieldType> $children
+     * @param Collection<int, FieldType> $children
      */
     private function isGrantedForAllDescendant(Collection $children): bool
     {

--- a/src/Entity/DataField.php
+++ b/src/Entity/DataField.php
@@ -267,10 +267,12 @@ class DataField implements \ArrayAccess, \IteratorAggregate
         throw new \Exception('Deprecated method');
     }
 
-    public function linkFieldType(PersistentCollection $fieldTypes)
+    /**
+     * @param Collection<int, FieldType> $fieldTypes
+     */
+    public function linkFieldType(Collection $fieldTypes)
     {
         $index = 0;
-        /** @var FieldType $fieldType */
         foreach ($fieldTypes as $fieldType) {
             if (!$fieldType->getDeleted()) {
                 /** @var DataField $child */

--- a/src/Entity/FieldType.php
+++ b/src/Entity/FieldType.php
@@ -3,6 +3,7 @@
 namespace EMS\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
 use EMS\CoreBundle\Entity\Helper\JsonDeserializer;
@@ -100,7 +101,7 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
     protected $parent;
 
     /**
-     * @var ArrayCollection|FieldType[]
+     * @var Collection<int, FieldType>
      * @ORM\OneToMany(targetEntity="FieldType", mappedBy="parent", cascade={"persist", "remove"})
      * @ORM\OrderBy({"orderKey" = "ASC"})
      */
@@ -461,6 +462,16 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
         return [];
     }
 
+    /**
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getExtraOption(string $key, $default = null)
+    {
+        return $this->getExtraOptions()[$key] ?? $default;
+    }
+
     public function getMinimumRole()
     {
         $options = $this->getOptions();
@@ -725,12 +736,14 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
     }
 
     /**
-     * Get children.
-     *
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return Collection<int, FieldType>
      */
-    public function getChildren()
+    public function getChildren(bool $all = false): Collection
     {
+        if ($all) {
+            return new ArrayCollection(\iterator_to_array($this->loopChildren()));
+        }
+
         return $this->children;
     }
 

--- a/src/Event/UpdateRevisionReferersEvent.php
+++ b/src/Event/UpdateRevisionReferersEvent.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Event;
 
 use EMS\CommonBundle\Common\EMSLink;
+use EMS\CoreBundle\Entity\Revision;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class UpdateRevisionReferersEvent extends Event
 {
-    private string $type;
-    private string $id;
+    private Revision $revision;
     private string $targetField;
     /** @var string[] */
     private array $removeOuuids;
@@ -21,10 +21,9 @@ class UpdateRevisionReferersEvent extends Event
      * @param string[] $removeOuuids
      * @param string[] $addOuuids
      */
-    public function __construct(string $type, string $id, string $targetField, array $removeOuuids, array $addOuuids)
+    public function __construct(Revision $revision, string $targetField, array $removeOuuids, array $addOuuids)
     {
-        $this->type = $type;
-        $this->id = $id;
+        $this->revision = $revision;
         $this->targetField = $targetField;
         $this->removeOuuids = $removeOuuids;
         $this->addOuuids = $addOuuids;
@@ -55,18 +54,8 @@ class UpdateRevisionReferersEvent extends Event
         return \array_map(fn (string $ouuid) => EMSLink::fromText($ouuid), $addOuuids);
     }
 
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
     public function getRefererOuuid(): string
     {
-        return $this->getType().':'.$this->getId();
+        return $this->revision->getEmsId();
     }
 }

--- a/src/Event/UpdateRevisionReferersEvent.php
+++ b/src/Event/UpdateRevisionReferersEvent.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Event;
 
+use EMS\CommonBundle\Common\EMSLink;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -13,72 +14,63 @@ class UpdateRevisionReferersEvent extends Event
 {
     public const NAME = 'ems_core.revision.update_referers';
 
-    private $targetField;
-    private $id;
-    private $toClean;
-    private $toCreate;
-    private $type;
+    private string $type;
+    private string $id;
+    private string $targetField;
+    /** @var string[] */
+    private array $removeOuuids;
+    /** @var string[] */
+    private array $addOuuids;
 
-    public function __construct(string $type, string $id, string $targetField, array $toCleanOuuids, array $toCreateOuuids)
+    /**
+     * @param string[] $removeOuuids
+     * @param string[] $addOuuids
+     */
+    public function __construct(string $type, string $id, string $targetField, array $removeOuuids, array $addOuuids)
     {
         $this->type = $type;
         $this->id = $id;
         $this->targetField = $targetField;
-        $this->toClean = $toCleanOuuids;
-        $this->toCreate = $toCreateOuuids;
+        $this->removeOuuids = $removeOuuids;
+        $this->addOuuids = $addOuuids;
     }
 
-    /**
-     * Return the name of the computed field where the back link is store.
-     *
-     * @return string
-     */
-    public function getTargetField()
+    public function getTargetField(): string
     {
         return $this->targetField;
     }
 
     /**
-     * List of UUIDs where the back link should be removed.
-     *
-     * @return array
+     * @return EMSLink[]
      */
-    public function getToCleanOuuids()
+    public function getRemoveEmsLinks(): array
     {
-        return \array_diff($this->toClean, $this->toCreate);
+        $removeOuuids = \array_diff($this->removeOuuids, $this->addOuuids);
+
+        return \array_map(fn (string $ouuid) => EMSLink::fromText($ouuid), $removeOuuids);
     }
 
     /**
-     * List of UUIDs where the back link should be added.
-     *
-     * @return array
+     * @return EMSLink[]
      */
-    public function getToCreateOuuids()
+    public function getAddEmsLinks(): array
     {
-        return \array_diff($this->toCreate, $this->toClean);
+        $addOuuids = \array_diff($this->addOuuids, $this->removeOuuids);
+
+        return \array_map(fn (string $ouuid) => EMSLink::fromText($ouuid), $addOuuids);
     }
 
-    /**
-     * Type of the object triggering the event.
-     *
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * Id of the object triggering the event.
-     *
-     * @return string
-     */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    public function getRefererOuuid()
+    public function getRefererOuuid(): string
     {
         return $this->getType().':'.$this->getId();
     }

--- a/src/Event/UpdateRevisionReferersEvent.php
+++ b/src/Event/UpdateRevisionReferersEvent.php
@@ -49,9 +49,7 @@ class UpdateRevisionReferersEvent extends Event
      */
     public function getAddEmsLinks(): array
     {
-        $addOuuids = \array_diff($this->addOuuids, $this->removeOuuids);
-
-        return \array_map(fn (string $ouuid) => EMSLink::fromText($ouuid), $addOuuids);
+        return \array_map(fn (string $ouuid) => EMSLink::fromText($ouuid), $this->addOuuids);
     }
 
     public function getRefererOuuid(): string

--- a/src/Event/UpdateRevisionReferersEvent.php
+++ b/src/Event/UpdateRevisionReferersEvent.php
@@ -1,19 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CoreBundle\Event;
 
 use EMS\CommonBundle\Common\EMSLink;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * Contains information to update 2 side links between objects.
- *
- * @author Mathieu De Keyzer <ems@theus.be>
- */
 class UpdateRevisionReferersEvent extends Event
 {
-    public const NAME = 'ems_core.revision.update_referers';
-
     private string $type;
     private string $id;
     private string $targetField;

--- a/src/EventListener/RevisionListener.php
+++ b/src/EventListener/RevisionListener.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\EventListener;
+
+use EMS\CommonBundle\Common\EMSLink;
+use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Event\UpdateRevisionReferersEvent;
+use EMS\CoreBundle\Exception\LockedException;
+use EMS\CoreBundle\Service\DataService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class RevisionListener implements EventSubscriberInterface
+{
+    private DataService $dataService;
+    private LoggerInterface $logger;
+
+    public function __construct(DataService $dataService, LoggerInterface $logger)
+    {
+        $this->dataService = $dataService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            UpdateRevisionReferersEvent::class => [
+                ['updateReferers', 0],
+            ],
+        ];
+    }
+
+    public function updateReferers(UpdateRevisionReferersEvent $event): void
+    {
+        $callback = function (string $type, string $targetField, string $referrerId, EMSLink $emsLink) {
+            try {
+                $form = null;
+                $revision = $this->dataService->initNewDraft($emsLink->getContentType(), $emsLink->getOuuid());
+                $data = $revision->getRawData();
+
+                if (!isset($data[$targetField])) {
+                    $data[$targetField] = [];
+                }
+
+                $currentData = $data[$targetField];
+
+                if ('remove' === $type && \in_array($referrerId, $currentData)) {
+                    $data[$targetField] = \array_values(\array_diff($currentData, [$referrerId]));
+                    $revision->setRawData($data);
+                    $this->dataService->finalizeDraft($revision, $form, null, false);
+                } elseif ('add' === $type && !\in_array($referrerId, $currentData)) {
+                    $data[$targetField][] = $referrerId;
+                    $revision->setRawData($data);
+                    $this->dataService->finalizeDraft($revision, $form, null, false);
+                } else {
+                    $this->dataService->discardDraft($revision);
+                }
+            } catch (LockedException $e) {
+                $this->logger->error('service.data.update_referrers_error', [
+                    EmsFields::LOG_CONTENTTYPE_FIELD => $emsLink->getContentType(),
+                    EmsFields::LOG_OUUID_FIELD => $emsLink->getOuuid(),
+                    EmsFields::LOG_EXCEPTION_FIELD => $e,
+                    EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                ]);
+            }
+        };
+
+        foreach ($event->getRemoveEmsLinks() as $removeEmsLink) {
+            $callback('remove', $event->getTargetField(), $event->getRefererOuuid(), $removeEmsLink);
+        }
+
+        foreach ($event->getAddEmsLinks() as $addEmsLink) {
+            $callback('add', $event->getTargetField(), $event->getRefererOuuid(), $addEmsLink);
+        }
+    }
+}

--- a/src/EventListener/RevisionListener.php
+++ b/src/EventListener/RevisionListener.php
@@ -37,7 +37,7 @@ final class RevisionListener implements EventSubscriberInterface
 
     public function updateReferers(UpdateRevisionReferersEvent $event): void
     {
-        $callback = function (string $type, string $targetField, string $referrerId, EMSLink $emsLink) {
+        $callback = function (string $type, string $targetField, string $referrerEmsId, EMSLink $emsLink) {
             try {
                 $form = null;
                 $revision = $this->dataService->initNewDraft($emsLink->getContentType(), $emsLink->getOuuid());
@@ -49,12 +49,12 @@ final class RevisionListener implements EventSubscriberInterface
 
                 $currentData = $data[$targetField];
 
-                if ('remove' === $type && \in_array($referrerId, $currentData)) {
-                    $data[$targetField] = \array_values(\array_diff($currentData, [$referrerId]));
+                if ('remove' === $type && \in_array($referrerEmsId, $currentData)) {
+                    $data[$targetField] = \array_values(\array_diff($currentData, [$referrerEmsId]));
                     $revision->setRawData($data);
                     $this->dataService->finalizeDraft($revision, $form, null, false);
-                } elseif ('add' === $type && !\in_array($referrerId, $currentData)) {
-                    $data[$targetField][] = $referrerId;
+                } elseif ('add' === $type && !\in_array($referrerEmsId, $currentData)) {
+                    $data[$targetField][] = $referrerEmsId;
                     $revision->setRawData($data);
                     $this->dataService->finalizeDraft($revision, $form, null, false);
                 } else {

--- a/src/Form/DataField/ContainerFieldType.php
+++ b/src/Form/DataField/ContainerFieldType.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Form\DataField;
 
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
+use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldModelTransformer;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldViewTransformer;
 use EMS\CoreBundle\Form\Field\IconPickerType;
@@ -34,17 +35,13 @@ class ContainerFieldType extends DataFieldType
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @see \EMS\CoreBundle\Form\DataField\DataFieldType::postFinalizeTreatment()
+     * {@inheritDoc}
      */
-    public function postFinalizeTreatment($type, $id, DataField $dataField, $previousData)
+    public function postFinalizeTreatment(Revision $revision, DataField $dataField, ?array $previousData): ?array
     {
-        if (!empty($previousData[$dataField->getFieldType()->getName()])) {
-            return $previousData[$dataField->getFieldType()->getName()];
-        }
+        $previousFieldData = $previousData[$dataField->giveFieldType()->getName()] ?? false;
 
-        return null;
+        return \is_array($previousFieldData) ? $previousFieldData : null;
     }
 
     /**

--- a/src/Form/DataField/DataFieldType.php
+++ b/src/Form/DataField/DataFieldType.php
@@ -68,6 +68,8 @@ abstract class DataFieldType extends AbstractType
      * Perfom field specfifc post-finalized treatment. It returns the children if it's a container.
      *
      * @param ?array<string, mixed> $previousData
+     *
+     * @return ?array<string, mixed>
      */
     public function postFinalizeTreatment(Revision $revision, DataField $dataField, ?array $previousData): ?array
     {

--- a/src/Form/DataField/DataFieldType.php
+++ b/src/Form/DataField/DataFieldType.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Form\DataField;
 
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
+use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Exception\ContentTypeStructureException;
 use EMS\CoreBundle\Form\DataField\Options\OptionsType;
 use EMS\CoreBundle\Form\Field\SelectPickerType;
@@ -66,13 +67,9 @@ abstract class DataFieldType extends AbstractType
     /**
      * Perfom field specfifc post-finalized treatment. It returns the children if it's a container.
      *
-     * @param string $type
-     * @param string $id
-     * @param array  $previousData
-     *
-     * @return array|null
+     * @param ?array<string, mixed> $previousData
      */
-    public function postFinalizeTreatment($type, $id, DataField $dataField, $previousData)
+    public function postFinalizeTreatment(Revision $revision, DataField $dataField, ?array $previousData): ?array
     {
         return $previousData;
     }

--- a/src/Form/DataField/DataLinkFieldType.php
+++ b/src/Form/DataField/DataLinkFieldType.php
@@ -47,7 +47,10 @@ class DataLinkFieldType extends DataFieldType
      */
     public function postFinalizeTreatment($type, $id, DataField $dataField, $previousData)
     {
-        if (!empty($dataField->getFieldType()->getExtraOptions()['updateReferersField'])) {
+        $extraOptions = $dataField->giveFieldType()->getExtraOptions() ?? [];
+        $updateReferersField = $extraOptions['updateReferersField'] ?? false;
+
+        if ($updateReferersField) {
             $referersToAdd = [];
             $referersToRemove = [];
 
@@ -61,7 +64,8 @@ class DataLinkFieldType extends DataFieldType
                 $referersToAdd = \is_array($currentRawData) ? $currentRawData : [$currentRawData];
             }
 
-            $this->dispatcher->dispatch(UpdateRevisionReferersEvent::NAME, new UpdateRevisionReferersEvent($type, $id, $dataField->getFieldType()->getExtraOptions()['updateReferersField'], $referersToRemove, $referersToAdd));
+            $event = new UpdateRevisionReferersEvent($type, $id, $updateReferersField, $referersToRemove, $referersToAdd);
+            $this->dispatcher->dispatch($event);
         }
 
         return parent::postFinalizeTreatment($type, $id, $dataField, $previousData);

--- a/src/Form/DataField/DataLinkFieldType.php
+++ b/src/Form/DataField/DataLinkFieldType.php
@@ -29,14 +29,14 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  */
 class DataLinkFieldType extends DataFieldType
 {
-    /** @var EventDispatcherInterface */
-    protected $dispatcher;
+    protected EventDispatcherInterface $dispatcher;
 
-    /**
-     * Contructor.
-     */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, FormRegistryInterface $formRegistry, ElasticsearchService $elasticsearchService, EventDispatcherInterface $dispatcher)
-    {
+    public function __construct(
+        AuthorizationCheckerInterface $authorizationChecker,
+        FormRegistryInterface $formRegistry,
+        ElasticsearchService $elasticsearchService,
+        EventDispatcherInterface $dispatcher
+    ) {
         parent::__construct($authorizationChecker, $formRegistry, $elasticsearchService);
         $this->dispatcher = $dispatcher;
     }

--- a/src/Form/DataField/DataLinkFieldType.php
+++ b/src/Form/DataField/DataLinkFieldType.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Form\DataField;
 
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
+use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Event\UpdateRevisionReferersEvent;
 use EMS\CoreBundle\Form\Field\AnalyzerPickerType;
 use EMS\CoreBundle\Form\Field\ObjectChoiceLoader;
@@ -42,10 +43,8 @@ class DataLinkFieldType extends DataFieldType
 
     /**
      * {@inheritdoc}
-     *
-     * @see \EMS\CoreBundle\Form\DataField\DataFieldType::postFinalizeTreatment()
      */
-    public function postFinalizeTreatment($type, $id, DataField $dataField, $previousData)
+    public function postFinalizeTreatment(Revision $revision, DataField $dataField, ?array $previousData): ?array
     {
         $extraOptions = $dataField->giveFieldType()->getExtraOptions() ?? [];
         $updateReferersField = $extraOptions['updateReferersField'] ?? false;
@@ -64,11 +63,11 @@ class DataLinkFieldType extends DataFieldType
                 $referersToAdd = \is_array($currentRawData) ? $currentRawData : [$currentRawData];
             }
 
-            $event = new UpdateRevisionReferersEvent($type, $id, $updateReferersField, $referersToRemove, $referersToAdd);
+            $event = new UpdateRevisionReferersEvent($revision, $updateReferersField, $referersToRemove, $referersToAdd);
             $this->dispatcher->dispatch($event);
         }
 
-        return parent::postFinalizeTreatment($type, $id, $dataField, $previousData);
+        return parent::postFinalizeTreatment($revision, $dataField, $previousData);
     }
 
     /**

--- a/src/Form/DataField/DataLinkFieldType.php
+++ b/src/Form/DataField/DataLinkFieldType.php
@@ -51,11 +51,14 @@ class DataLinkFieldType extends DataFieldType
             $referersToAdd = [];
             $referersToRemove = [];
 
-            if (!empty($previousData[$dataField->getFieldType()->getName()])) {
-                $referersToRemove = $previousData[$dataField->getFieldType()->getName()];
+            $currentRawData = $dataField->getRawData();
+            $previousRawData = $previousData[$dataField->getFieldType()->getName()] ?? null;
+
+            if ($previousRawData) {
+                $referersToRemove = \is_array($previousRawData) ? $previousRawData : [$previousRawData];
             }
-            if (!empty($dataField->getRawData())) {
-                $referersToAdd = $dataField->getRawData();
+            if ($currentRawData) {
+                $referersToAdd = \is_array($currentRawData) ? $currentRawData : [$currentRawData];
             }
 
             $this->dispatcher->dispatch(UpdateRevisionReferersEvent::NAME, new UpdateRevisionReferersEvent($type, $id, $dataField->getFieldType()->getExtraOptions()['updateReferersField'], $referersToRemove, $referersToAdd));

--- a/src/Form/DataField/JsonMenuNestedEditorFieldType.php
+++ b/src/Form/DataField/JsonMenuNestedEditorFieldType.php
@@ -4,39 +4,37 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Form\DataField;
 
+use Doctrine\Common\Collections\Collection;
+use EMS\CommonBundle\Json\JsonMenuNested;
+use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Entity\Revision;
+use EMS\CoreBundle\Event\UpdateRevisionReferersEvent;
 use EMS\CoreBundle\Form\Field\AnalyzerPickerType;
 use EMS\CoreBundle\Form\Field\IconPickerType;
 use EMS\CoreBundle\Service\ElasticsearchService;
+use EMS\Helpers\Standard\Type;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRegistryInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class JsonMenuNestedEditorFieldType extends DataFieldType
 {
-    /** @var FormFactoryInterface */
-    private $formFactory;
-    /** @var UrlGeneratorInterface */
-    private $urlGenerator;
+    protected EventDispatcherInterface $dispatcher;
 
     public function __construct(
-        FormFactoryInterface $formFactory,
         AuthorizationCheckerInterface $authorizationChecker,
         FormRegistryInterface $formRegistry,
         ElasticsearchService $elasticsearchService,
-        UrlGeneratorInterface $urlGenerator
+        EventDispatcherInterface $dispatcher
     ) {
         parent::__construct($authorizationChecker, $formRegistry, $elasticsearchService);
-
-        $this->formFactory = $formFactory;
-        $this->urlGenerator = $urlGenerator;
+        $this->dispatcher = $dispatcher;
     }
 
     public function getLabel(): string
@@ -116,5 +114,78 @@ class JsonMenuNestedEditorFieldType extends DataFieldType
 
         $view->vars['disabled'] = !$this->authorizationChecker->isGranted($fieldType->getMinimumRole());
         $view->vars['revision'] = $revision;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postFinalizeTreatment(Revision $revision, DataField $dataField, ?array $previousData): ?array
+    {
+        $fieldType = $dataField->giveFieldType();
+
+        $menuCurrent = JsonMenuNested::fromStructure(Type::string($dataField->getRawData()));
+        $menuPrevious = JsonMenuNested::fromStructure($previousData[$fieldType->getName()] ?? '{}');
+
+        if ($menuCurrent->toArrayStructure() === $menuPrevious->toArrayStructure()) {
+            return $previousData;
+        }
+
+        $nodeTypeDataLinksUpdateReferrer = $this->getNodeTypeDataLinksUpdateReferrer($fieldType);
+
+        foreach ($nodeTypeDataLinksUpdateReferrer as $nodeType => $dataLinksUpdateReferrer) {
+            $callbackNodeTypes = fn (JsonMenuNested $i) => $i->getType() === $nodeType;
+            $menuCurrentItems = $menuCurrent->filterChildren($callbackNodeTypes);
+            $menuPreviousItems = $menuPrevious->filterChildren($callbackNodeTypes);
+
+            $menuUpdatedItems = $menuCurrentItems->diffChildren($menuPreviousItems);
+            $menuRemovedItems = $menuPreviousItems->diffChildren($menuCurrentItems);
+
+            if (0 === \count($menuUpdatedItems) && 0 === \count($menuRemovedItems)) {
+                continue;
+            }
+
+            foreach ($dataLinksUpdateReferrer as $dataLink => $updateReferrer) {
+                $callbackItemHasProperty = fn (JsonMenuNested $i) => $i->getObject()[$dataLink] ?? null;
+
+                /** @var string[] $referrersUpdate */
+                $referrersUpdate = \array_filter($menuUpdatedItems->getChildren($callbackItemHasProperty));
+                /** @var string[] $referrersRemove */
+                $referrersRemove = \array_filter($menuRemovedItems->getChildren($callbackItemHasProperty));
+
+                $event = new UpdateRevisionReferersEvent($revision, $updateReferrer, $referrersRemove, $referrersUpdate);
+                $this->dispatcher->dispatch($event);
+            }
+        }
+
+        return $previousData;
+    }
+
+    /**
+     * Key node type, value array with key data link field type name, value update referrers.
+     *
+     * @return array<string, array<string, string>>
+     */
+    private function getNodeTypeDataLinksUpdateReferrer(FieldType $fieldType): array
+    {
+        /** @var Collection<int, FieldType> $children */
+        $children = $fieldType->getChildren()->filter(fn (FieldType $f) => !$f->getDeleted());
+
+        $nodeDataLinksUpdateReferrers = [];
+        foreach ($children as $node) {
+            $nodeChildren = $node->getChildren(true);
+            if ($nodeChildren->isEmpty()) {
+                continue;
+            }
+
+            /** @var Collection<int, FieldType> $dataLinkFieldTypes */
+            $dataLinkFieldTypes = $nodeChildren->filter(fn (FieldType $f) => DataLinkFieldType::class === $f->getType());
+            foreach ($dataLinkFieldTypes as $dataLinkFieldType) {
+                if ($updateReferrersField = $dataLinkFieldType->getExtraOption('updateReferersField', false)) {
+                    $nodeDataLinksUpdateReferrers[$node->getName()][$dataLinkFieldType->getName()] = $updateReferrersField;
+                }
+            }
+        }
+
+        return $nodeDataLinksUpdateReferrers;
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,6 +17,11 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="110" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
+        <service id="ems_core.event_listener.revision_listener" class="EMS\CoreBundle\EventListener\RevisionListener">
+            <argument type="service" id="ems.service.data"/>
+            <argument type="service" id="emsco.logger" />
+            <tag name="kernel.event_subscriber" />
+        </service>
 
         <!-- core service -->
         <service id="ems.dashboard.manager" class="EMS\CoreBundle\Core\Dashboard\DashboardManager">

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -382,8 +382,6 @@ services:
     EMS\CoreBundle\Service\DataService:
         class: EMS\CoreBundle\Service\DataService
         arguments: ['@doctrine', '@security.authorization_checker', '@security.token_storage', '%ems_core.lock_time%', '@ems_common.service.elastica', '@ems.service.mapping', '%ems_core.instance_id%', '@session', '@form.factory', '@service_container', '@form.registry', '@event_dispatcher', '@ems.service.contenttype', '%ems_core.private_key%', '@emsco.logger', '@emsco.logger.audit', '@ems_common.storage.manager', '@twig', '@app.twig_extension', '@ems.service.user', '@EMS\CoreBundle\Repository\RevisionRepository', '@ems.service.environment', '@ems.service.search', '@ems.service.index', '%ems_core.pre_generated_ouuids%', '@ems.service.revision.post_processing']
-        tags:
-            - { name: kernel.event_listener, event: ems_core.revision.update_referers, method: updateReferers, priority: 0 }
     ems.service.revision.post_processing:
         class: EMS\CoreBundle\Service\Revision\PostProcessingService
         arguments: ['@twig', '@form.factory', '@emsco.logger']

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -110,7 +110,7 @@ services:
             - { name: form.type }
     ems.fieldtype.json_menu_nested_editor:
         class: EMS\CoreBundle\Form\DataField\JsonMenuNestedEditorFieldType
-        arguments: ['@form.factory', '@security.authorization_checker', '@form.registry', '@ems.service.elasticsearch', '@router']
+        arguments: ['@security.authorization_checker', '@form.registry', '@ems.service.elasticsearch', '@event_dispatcher']
         tags:
             - { name: ems.form.datafieldtype, alias: json_menu_nested }
             - { name: form.type }

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -1875,7 +1875,7 @@ class DataService
                 $currentData = $data[$targetField];
 
                 if ('remove' === $type && \in_array($referrerId, $currentData)) {
-                    $data[$targetField] = \array_diff($currentData, [$referrerId]);
+                    $data[$targetField] = \array_values(\array_diff($currentData, [$referrerId]));
                     $revision->setRawData($data);
                     $this->finalizeDraft($revision, $form, null, false);
                 } elseif ('add' === $type && !\in_array($referrerId, $currentData)) {

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -880,7 +880,7 @@ class DataService
             $this->auditLogger->notice('log.revision.finalized', LogRevisionContext::update($revision));
 
             try {
-                $this->postFinalizeTreatment($revision->giveContentType()->getName(), $revision->getOuuid(), $form->get('data'), $previousObjectArray);
+                $this->postFinalizeTreatment($revision, $form->get('data'), $previousObjectArray);
             } catch (Exception $e) {
                 $this->logger->warning('service.data.post_finalize_failed', [
                     EmsFields::LOG_REVISION_ID_FIELD => $revision->getId(),
@@ -944,21 +944,16 @@ class DataService
     }
 
     /**
-     * Parcours all fields and call DataFieldsType postFinalizeTreament function.
-     *
-     * @param string     $type
-     * @param string     $id
-     * @param array|null $previousObjectArray
+     * Loop over all fields and call postFinalizeTreatment.
      */
-    public function postFinalizeTreatment($type, $id, FormInterface $form, $previousObjectArray)
+    public function postFinalizeTreatment(Revision $revision, FormInterface $form, ?array $previousObjectArray)
     {
-        /** @var FormInterface $subForm */
         foreach ($form->all() as $subForm) {
             if ($subForm->getNormData() instanceof DataField) {
                 /** @var DataFieldType $dataFieldType */
                 $dataFieldType = $subForm->getConfig()->getType()->getInnerType();
-                $childrenPreviousData = $dataFieldType->postFinalizeTreatment($type, $id, $subForm->getNormData(), $previousObjectArray);
-                $this->postFinalizeTreatment($type, $id, $subForm, $childrenPreviousData);
+                $childrenPreviousData = $dataFieldType->postFinalizeTreatment($revision, $subForm->getNormData(), $previousObjectArray);
+                $this->postFinalizeTreatment($revision, $subForm, $childrenPreviousData);
             }
         }
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

# Update referrers

If a data link field type has the extra option 'update referrers field' defined, then on post finalization an event will be dispatched.
They event listener will search the linked document and update the referrers field.

## Example: 
- **Club** content type with a multiple data link field called **players**. 
- **Player** content type with a single or multiple data link field type called club(s) and a update referrers value **players**
If we create or update a player and we change the club, the referred club field **players** will be updated.

## Refactor
- Moved to the update referrer logic to a new revision event subscriber.
- Duplicated for loop logic (add/remove) moved to simple callback
- Changed signature postFinalizeTreatment passing revision instead of string type and ouuid

# Status
We are not quite happy, because it will create a lot of revisions. Maybe we should use the reindex instead of creating revisions

