### PR TITLE
fix: save/edit publish revision

### DIFF
--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -182,10 +182,8 @@ class EditController extends AbstractController
                     $revision = $this->revisionService->saveVersion($revision, $objectArray, $versionTag, $form);
                 } else {
                     $this->revisionService->save($revision, $objectArray);
-                    if (null !== $revision->getEndTime()) {
-                        foreach ($revision->getEnvironments() as $publishedEnvironment) {
-                            $this->publishService->publish($revision, $publishedEnvironment);
-                        }
+                    foreach ($revision->getEnvironments() as $publishedEnvironment) {
+                        $this->publishService->publish($revision, $publishedEnvironment);
                     }
                 }
 

--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -113,8 +113,12 @@ class EditController extends AbstractController
             throw new NotFoundException('ContentType not found!');
         }
 
-        if ($revision->getEndTime() && !$this->isGranted(Roles::ROLE_SUPER)) {
+        if ($revision->hasEndTime() && !$this->isGranted(Roles::ROLE_SUPER)) {
             throw new ElasticmsException($this->translator->trans('log.data.revision.only_super_can_finalize_an_archive', LogRevisionContext::read($revision), EMSCoreBundle::TRANS_DOMAIN));
+        }
+
+        if (!$revision->getDraft() && $revision->isPublished($contentType->giveEnvironment()->getName())) {
+            throw new \RuntimeException('Only a draft is allowed for editing the revision!');
         }
 
         if ($request->isMethod('GET') && null != $revision->getAutoSave()) {

--- a/src/Form/Form/RevisionType.php
+++ b/src/Form/Form/RevisionType.php
@@ -43,23 +43,32 @@ class RevisionType extends AbstractType
                 'referrer-ems-id' => $revision && $revision->hasOuuid() ? $revision->getEmsId() : null,
         ]);
 
-        if ($revision && null === $revision->getEndTime()) {
-            $builder->add('save', SubmitEmsType::class, [
-                'label' => 'form.form.revision-type.save-draft-label',
-                'attr' => ['class' => 'btn btn-default btn-sm'],
-                'icon' => 'fa fa-save',
-            ]);
-        } elseif ($revision) {
-            $publishedEnvironmentLabels = $revision->getEnvironments()->map(fn (Environment $e) => $e->getLabel());
-            //update published revision in other environment
-            $builder->add('save', SubmitEmsType::class, [
-                'label' => 'form.form.revision-type.publish-label',
-                'label_translation_parameters' => [
-                    '%environment%' => \implode(', ', $publishedEnvironmentLabels->toArray()),
-                ],
-                'attr' => ['class' => 'btn btn-primary btn-sm'],
-                'icon' => 'glyphicon glyphicon-open',
-            ]);
+        if ($revision) {
+            if ($revision->getDraft()) {
+                $builder->add('save', SubmitEmsType::class, [
+                    'label' => 'form.form.revision-type.save-draft-label',
+                    'attr' => ['class' => 'btn btn-default btn-sm'],
+                    'icon' => 'fa fa-save',
+                ]);
+            } else {
+                $publishedEnvironmentLabels = $revision->getEnvironments()->map(fn (Environment $e) => $e->getLabel());
+                if (\count($publishedEnvironmentLabels) > 0) {
+                    $builder->add('save', SubmitEmsType::class, [
+                        'label' => 'form.form.revision-type.publish-label',
+                        'label_translation_parameters' => [
+                            '%environment%' => \implode(', ', $publishedEnvironmentLabels->toArray()),
+                        ],
+                        'attr' => ['class' => 'btn btn-primary btn-sm'],
+                        'icon' => 'glyphicon glyphicon-open',
+                    ]);
+                } else {
+                    $builder->add('save', SubmitEmsType::class, [
+                        'label' => 'form.form.revision-type.save-label',
+                        'attr' => ['class' => 'btn btn-primary btn-sm'],
+                        'icon' => 'fa fa-save',
+                    ]);
+                }
+            }
         }
 
         $builder->get('data')

--- a/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/src/Resources/translations/EMSCoreBundle.en.yml
@@ -181,6 +181,7 @@ form.form.release.name: Name
 form.form.revision-type.copy-label: Copy
 form.form.revision-type.paste-label: Paste
 form.form.revision-type.save-draft-label: 'Save as draft'
+form.form.revision-type.save-label: 'Save'
 form.form.revision-type.publish-label: 'Save and publish in %environment%'
 form.form.revision-type.publish-version-tags-label: 'Save, tag and publish in %environment%'
 form.form_field.wysiwyg.content_css.label: 'Content CSS (override styles sets''s config)'

--- a/src/Resources/views/elements/revision-toolbar.html.twig
+++ b/src/Resources/views/elements/revision-toolbar.html.twig
@@ -125,7 +125,7 @@
 										'label': 'views.elements.revision-toolbar-html.add-to-release'|trans(),
 										'icon': 'glyphicon glyphicon-pushpin' }%}</li>
 							{% endif %}
-							{% if instance.contentType.fieldType.fieldsRoles|one_granted(true) %}
+							{% if is_granted('ROLE_SUPER') and instance.contentType.environment not in environments %}
 								<li>{% include '@EMSCore/elements/get-button.html.twig' with {
 									'url': path('emsco_edit_revision', {'revisionId': revisionId}),
 									'btnClass': ' ',


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

* Edit a revision that is not published in any environments
    * Showing a blue submit button"Save and publish in" >  fixed now showing blue "Save" button. Because we will only update the revision in the database.
* Edit archived revision that is published in live environment
    * Showing a gray submit button "Save as draft" > fixed now showing blue "Save and publish in Live"
    
On save we only published if they revision had an endTime, this check could be removed. If we save a revision and it has environments, we should publish.

Creating a draft -> new revision (no environments), so will not conflict with above logic.


