### PR TITLE
fix: reload data reindex (not working)

### DIFF
--- a/src/Command/ReindexCommand.php
+++ b/src/Command/ReindexCommand.php
@@ -36,12 +36,10 @@ class ReindexCommand extends EmsCommand
     protected $dataService;
     /** @var string */
     private $instanceId;
-    /** @var int */
-    private $count;
-    /** @var int */
-    private $deleted;
-    /** @var int */
-    private $error;
+    private int $count = 0;
+    private int $deleted = 0;
+    private int $reloaded = 0;
+    private int $error = 0;
     /** @var Bulker */
     private $bulker;
     /** @var string */
@@ -58,10 +56,6 @@ class ReindexCommand extends EmsCommand
         $this->bulker = $bulker;
         $this->defaultBulkSize = $defaultBulkSize;
         parent::__construct();
-
-        $this->count = 0;
-        $this->deleted = 0;
-        $this->error = 0;
     }
 
     protected function configure(): void
@@ -194,7 +188,8 @@ class ReindexCommand extends EmsCommand
                         ]);
                     } else {
                         if ($reloadData) {
-                            $this->dataService->reloadData($revision);
+                            $reloadedResult = $this->dataService->reloadData($revision, false);
+                            $this->reloaded += $reloadedResult;
                         }
 
                         $rawData = $revision->getRawData();
@@ -204,7 +199,7 @@ class ReindexCommand extends EmsCommand
                     $progress->advance();
                 }
 
-                $em->clear(Revision::class);
+                $em->clear();
 
                 ++$page;
                 $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page);
@@ -216,6 +211,10 @@ class ReindexCommand extends EmsCommand
             $output->writeln('');
 
             $output->writeln(' '.$this->count.' objects are re-indexed in '.$index.' ('.$this->deleted.' not indexed as deleted, '.$this->error.' with indexing error)');
+
+            if ($this->reloaded > 0) {
+                $output->writeln(sprintf('%d documents are reloaded', $this->reloaded));
+            }
 
             $this->logger->notice('command.reindex.end', [
                 EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_UPDATE,

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -517,7 +517,6 @@ class DataController extends AbstractController
 
         try {
             $this->dataService->reloadData($revision);
-            $this->dataService->sign($revision);
 
             /** @var Environment $environment */
             foreach ($revision->getEnvironments() as $environment) {
@@ -529,8 +528,6 @@ class DataController extends AbstractController
                     }
                 }
             }
-            $em->persist($revision);
-            $em->flush();
         } catch (\Throwable $e) {
             $this->logger->warning('log.data.revision.reindex_failed', \array_merge(LogRevisionContext::update($revision), [
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -1613,7 +1613,8 @@ class DataService
 
         $this->lockRevision($revision, null, false, 'SYSTEM_RELOAD');
         $this->em->persist($revision);
-        $this->em->flush();
+
+        if ($flush) { $this->em->flush(); }
 
         return 1;
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Not working! Keep getting that the revision is not locked correctly. Doctrine is presisting when he should not do anything. Maybe do a clone? 