### PR TITLE
fix: reload data reindex

### DIFF
--- a/src/Command/ReindexCommand.php
+++ b/src/Command/ReindexCommand.php
@@ -36,12 +36,10 @@ class ReindexCommand extends EmsCommand
     protected $dataService;
     /** @var string */
     private $instanceId;
-    /** @var int */
-    private $count;
-    /** @var int */
-    private $deleted;
-    /** @var int */
-    private $error;
+    private int $count = 0;
+    private int $deleted = 0;
+    private int $reloaded = 0;
+    private int $error = 0;
     /** @var Bulker */
     private $bulker;
     /** @var string */
@@ -58,10 +56,6 @@ class ReindexCommand extends EmsCommand
         $this->bulker = $bulker;
         $this->defaultBulkSize = $defaultBulkSize;
         parent::__construct();
-
-        $this->count = 0;
-        $this->deleted = 0;
-        $this->error = 0;
     }
 
     protected function configure(): void
@@ -194,7 +188,8 @@ class ReindexCommand extends EmsCommand
                         ]);
                     } else {
                         if ($reloadData) {
-                            $this->dataService->reloadData($revision);
+                            $reloadedResult = $this->dataService->reloadData($revision, false);
+                            $this->reloaded += $reloadedResult;
                         }
 
                         $rawData = $revision->getRawData();
@@ -204,7 +199,8 @@ class ReindexCommand extends EmsCommand
                     $progress->advance();
                 }
 
-                $em->clear(Revision::class);
+                $em->flush();
+                $em->clear();
 
                 ++$page;
                 $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page);
@@ -216,6 +212,10 @@ class ReindexCommand extends EmsCommand
             $output->writeln('');
 
             $output->writeln(' '.$this->count.' objects are re-indexed in '.$index.' ('.$this->deleted.' not indexed as deleted, '.$this->error.' with indexing error)');
+
+            if ($this->reloaded > 0) {
+                $output->writeln(\sprintf('%d documents are reloaded', $this->reloaded));
+            }
 
             $this->logger->notice('command.reindex.end', [
                 EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_UPDATE,

--- a/src/Command/ReindexCommand.php
+++ b/src/Command/ReindexCommand.php
@@ -188,8 +188,7 @@ class ReindexCommand extends EmsCommand
                         ]);
                     } else {
                         if ($reloadData) {
-                            $reloadedResult = $this->dataService->reloadData($revision, false);
-                            $this->reloaded += $reloadedResult;
+                            $this->reloaded += $this->dataService->reloadData($revision, false);
                         }
 
                         $rawData = $revision->getRawData();

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -513,11 +513,8 @@ class DataController extends AbstractController
             throw $this->createNotFoundException('Revision not found');
         }
 
-        $this->dataService->lockRevision($revision);
-
         try {
             $this->dataService->reloadData($revision);
-            $this->dataService->sign($revision);
 
             /** @var Environment $environment */
             foreach ($revision->getEnvironments() as $environment) {
@@ -529,8 +526,6 @@ class DataController extends AbstractController
                     }
                 }
             }
-            $em->persist($revision);
-            $em->flush();
         } catch (\Throwable $e) {
             $this->logger->warning('log.data.revision.reindex_failed', \array_merge(LogRevisionContext::update($revision), [
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),

--- a/src/Entity/Revision.php
+++ b/src/Entity/Revision.php
@@ -8,8 +8,10 @@ use Doctrine\ORM\Mapping as ORM;
 use EMS\CommonBundle\Common\ArrayHelper\RecursiveMapper;
 use EMS\CommonBundle\Common\Standard\Type;
 use EMS\CoreBundle\Core\Revision\RawDataTransformer;
+use EMS\CoreBundle\Exception\LockedException;
 use EMS\CoreBundle\Exception\NotLockedException;
 use EMS\CoreBundle\Service\Mapping;
+use EMS\Helpers\Standard\DateTime;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
@@ -242,6 +244,17 @@ class Revision implements EntityInterface
      */
     private Collection $releases;
 
+    private bool $selfUpdate = false;
+
+    public function enableSelfUpdate(): void
+    {
+        if ($this->getDraft()) {
+            throw new LockedException($this);
+        }
+
+        $this->selfUpdate = true;
+    }
+
     /**
      * @ORM\PrePersist
      * @ORM\PreUpdate
@@ -253,7 +266,11 @@ class Revision implements EntityInterface
             $this->created = $this->modified;
         }
 
-        if (null == $this->lockBy || null == $this->lockUntil || new \DateTime() > $this->lockUntil) {
+        if ($this->selfUpdate && $this->isLocked()) {
+            throw new LockedException($this);
+        }
+
+        if (!$this->selfUpdate && !$this->isLockedBy()) {
             throw new NotLockedException($this);
         }
     }
@@ -654,11 +671,14 @@ class Revision implements EntityInterface
         return $this->getLockBy() !== $username && $this->isLocked();
     }
 
+    public function isLockedBy(): bool
+    {
+        return null !== $this->lockBy && null !== $this->lockUntil && $this->isLocked();
+    }
+
     public function isLocked(): bool
     {
-        $now = new \DateTime();
-
-        return $now < $this->getLockUntil();
+        return DateTime::create('now') < $this->getLockUntil();
     }
 
     /**

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -1571,16 +1571,14 @@ class DataService
         }
     }
 
-    /**
-     * @return array
-     *
-     * @throws Throwable
-     */
-    public function reloadData(Revision $revision)
+    public function reloadData(Revision $revision, bool $flush = true): int
     {
+        $revisionHash = $revision->getHash();
+        $reloadRevision = clone $revision;
+
         $finalizedBy = false;
         $finalizationDate = false;
-        $objectArray = $revision->getRawData();
+        $objectArray = $reloadRevision->getRawData();
         if (isset($objectArray[Mapping::FINALIZED_BY_FIELD])) {
             $finalizedBy = $objectArray[Mapping::FINALIZED_BY_FIELD];
         }
@@ -1588,12 +1586,12 @@ class DataService
             $finalizationDate = $objectArray[Mapping::FINALIZATION_DATETIME_FIELD];
         }
 
-        $builder = $this->formFactory->createBuilder(RevisionType::class, $revision, ['raw_data' => $revision->getRawData()]);
+        $builder = $this->formFactory->createBuilder(RevisionType::class, $reloadRevision, ['raw_data' => $reloadRevision->getRawData()]);
         $form = $builder->getForm();
 
-        $objectArray = $revision->getRawData();
-        $this->updateDataStructure($revision->giveContentType()->getFieldType(), $form->get('data')->getNormData());
-        $this->propagateDataToComputedField($form->get('data'), $objectArray, $revision->giveContentType(), $revision->giveContentType()->getName(), $revision->getOuuid());
+        $objectArray = $reloadRevision->getRawData();
+        $this->updateDataStructure($reloadRevision->giveContentType()->getFieldType(), $form->get('data')->getNormData());
+        $this->propagateDataToComputedField($form->get('data'), $objectArray, $reloadRevision->giveContentType(), $reloadRevision->giveContentType()->getName(), $reloadRevision->getOuuid(), false, false);
 
         if (false !== $finalizedBy) {
             $objectArray[Mapping::FINALIZED_BY_FIELD] = $finalizedBy;
@@ -1602,9 +1600,24 @@ class DataService
             $objectArray[Mapping::FINALIZATION_DATETIME_FIELD] = $finalizationDate;
         }
 
-        $revision->setRawData($objectArray);
+        $reloadRevision->setRawData($objectArray);
+        $this->sign($reloadRevision);
 
-        return $objectArray;
+        if ($reloadRevision->getHash() === $revisionHash) {
+            return 0;
+        }
+
+        $revision->setRawData($objectArray);
+        $this->sign($revision);
+
+        $revision->enableSelfUpdate();
+        $this->em->persist($revision);
+
+        if ($flush) {
+            $this->em->flush();
+        }
+
+        return 1;
     }
 
     public function getSubmitData(FormInterface $form)


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The rawData gets recomputed/reloaded and indexed in environment, but we are not saving it to the database.

On reindex the postprocessing was not passing finalized and migration false.

New selfUpdate property on Revision: for allowing revision sql updates without locking