### PR TITLE
fix: dataService issues

### DIFF
--- a/src/Repository/RevisionRepository.php
+++ b/src/Repository/RevisionRepository.php
@@ -557,19 +557,6 @@ class RevisionRepository extends EntityRepository
         return (int) $qb->getQuery()->execute();
     }
 
-    public function lockRevision(int $revisionId, string $username, \DateTimeInterface $lockUntil): int
-    {
-        $qb = $this->createQueryBuilder('r')->update()
-            ->set('r.lockBy', '?1')
-            ->set('r.lockUntil', '?2')
-            ->where('r.id = ?3')
-            ->setParameter(1, $username)
-            ->setParameter(2, $lockUntil, Type::DATETIME)
-            ->setParameter(3, $revisionId);
-
-        return (int) $qb->getQuery()->execute();
-    }
-
     public function finaliseRevision(ContentType $contentType, string $ouuid, \DateTime $now, string $lockUser): int
     {
         $qb = $this->createQueryBuilder('r')->update()

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -238,14 +238,13 @@ class DataService
 
         $twigExtension = $this->container->get('app.twig_extension');
 
-        if (!$username && $twigExtension instanceof AppExtension && $twigExtension->oneGranted($revision->giveContentType()->getFieldType()->getFieldsRoles(), $super)) {
+        if (!$username && $twigExtension instanceof AppExtension && !$twigExtension->oneGranted($revision->giveContentType()->getFieldType()->getFieldsRoles(), $super)) {
             throw new PrivilegeException($revision);
         }
         //TODO: test circles
 
-        $this->revRepository->lockRevision(Type::integer($revision->getId()), $lockerUsername, new \DateTime($this->lockTime));
-
         $revision->setLockBy($lockerUsername);
+
         if ($username) {
             //lock by a console script
             $revision->setLockUntil(new \DateTime('+30 seconds'));


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

- PrivelegeException should only be thrown if oneGranted returns false
- the lockRevision repository function (only used by dataService) is overkill and causing NotLockException