### PR TITLE
fix: json menu nested descendant grant

### DIFF
--- a/doc/twig/jsonMenuNested.md
+++ b/doc/twig/jsonMenuNested.md
@@ -98,12 +98,27 @@ In the html string you can access the option **context** and:
 ```twig
     {% set context = { 'title': 'Example' } %}
     {% set pageButtons %}
-        {{ '<button class="btn-test btn btn-sm btn-primary" data-item-id="{{ item.id }}">{{ item }}</button>' }}
-        {{ '{{ buttons.edit|raw }}' }}
-        {{ '{{ buttons.delete|raw }}' }}
+        {% verbatim %}  
+            {{ '<button class="btn-test btn btn-sm btn-primary" data-item-id="{{ item.id }}">{{ item }}</button>' }}
+            {{ '{{ buttons.edit|raw }}' }}
+            {{ '{{ buttons.delete|raw }}' }}
+        {% endverbatim %}  
     {% endset %}
     {% set pageExtra %}
-        {{ '<div class="well p-2 m-2">{{ buttons.view|raw }} {{ title }} : {{ item.object.label }}</div>' }}
+        {% verbatim %} 
+            {{ '<div class="well p-2 m-2">{{ buttons.view|raw }} {{ title }} : {{ item.object.label }}</div>' }}
+        {% endverbatim %}
+    {% endset %}
+    {% set rootButtons %}
+         {% verbatim %}       
+            {% if is_granted('ROLE_PUBLISHER') %}
+                {{ buttons.add|raw }}
+                {{ buttons.more|raw }}
+            {% endif %}
+            <div class="pull-right">
+                <button class="btn btn-sm btn-default">Extra button</button>
+            </div>
+        {% endverbatim %}
     {% endset %}
     
     {{ emsco_json_menu_nested({
@@ -121,6 +136,11 @@ In the html string you can access the option **context** and:
                 'type': 'item_action',
                 'item_type': 'page',
                 'html': (pageButtons)
+            },
+            {
+                'type': 'item_action',
+                'item_type': 'root',
+                'html': (rootButtons)
             }
         ],
     }) }}

--- a/src/Core/Revision/Json/JsonMenuNestedDefinition.php
+++ b/src/Core/Revision/Json/JsonMenuNestedDefinition.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Core\Revision\Json;
 
-use Doctrine\Common\Collections\Collection;
 use EMS\CommonBundle\Common\Standard\Json;
 use EMS\CommonBundle\Json\JsonMenuNested;
 use EMS\CoreBundle\Entity\FieldType;
@@ -272,9 +271,8 @@ final class JsonMenuNestedDefinition
         if (!$this->isGranted() || !$this->isGrantedFieldType($fieldType)) {
             $optionActions = \array_filter(['preview' => $optionActions['preview'] ?? null]);
         }
-        $isGrantedForAllDescendant = $this->isGrantedForAllDescendant($fieldType->getChildren());
 
-        if ('root' === $nodeType && $isGrantedForAllDescendant) {
+        if ('root' === $nodeType) {
             $optionActions = \array_filter([
                 'add' => $optionActions['add'] ?? ['deny' => ['root']],
                 'copy' => $optionActions['copy'] ?? ['deny' => ['root']],
@@ -290,9 +288,6 @@ final class JsonMenuNestedDefinition
                 continue;
             }
             if (!\in_array($actionName, ['copy', 'preview']) && null === $this->revision) {
-                continue;
-            }
-            if (!\in_array($actionName, ['preview', 'move', 'edit']) && !$isGrantedForAllDescendant) {
                 continue;
             }
 
@@ -330,18 +325,5 @@ final class JsonMenuNestedDefinition
         }
 
         return $types;
-    }
-
-    /**
-     * @param Collection<string, FieldType> $children
-     */
-    private function isGrantedForAllDescendant(Collection $children): bool
-    {
-        $isGrantedForAllDescendant = true;
-        foreach ($children as $child) {
-            $isGrantedForAllDescendant = $isGrantedForAllDescendant && $this->isGrantedFieldType($child) && $this->isGrantedForAllDescendant($child->getChildren());
-        }
-
-        return $isGrantedForAllDescendant;
     }
 }

--- a/src/Core/Revision/Json/JsonMenuNestedDefinition.php
+++ b/src/Core/Revision/Json/JsonMenuNestedDefinition.php
@@ -207,11 +207,11 @@ final class JsonMenuNestedDefinition
     private function buildNodes(array $optionActions): array
     {
         $nodes = [
-            'root' => [
-                'id' => 'root',
-                'name' => 'root',
+            '_root' => [
+                'id' => '_root',
+                'name' => '_root',
                 'addNodes' => $this->buildAddNodes($this->fieldType),
-                'actions' => $this->buildNodeActions($this->fieldType, 'root', $optionActions),
+                'actions' => $this->buildNodeActions($this->fieldType, '_root', $optionActions),
             ],
         ];
 
@@ -272,11 +272,11 @@ final class JsonMenuNestedDefinition
             $optionActions = \array_filter(['preview' => $optionActions['preview'] ?? null]);
         }
 
-        if ('root' === $nodeType) {
+        if ('_root' === $nodeType) {
             $optionActions = \array_filter([
-                'add' => $optionActions['add'] ?? ['deny' => ['root']],
-                'copy' => $optionActions['copy'] ?? ['deny' => ['root']],
-                'paste' => $optionActions['paste'] ?? ['deny' => ['root']],
+                'add' => $optionActions['add'] ?? ['deny' => ['_root']],
+                'copy' => $optionActions['copy'] ?? ['deny' => ['_root']],
+                'paste' => $optionActions['paste'] ?? ['deny' => ['_root']],
             ]);
         }
 

--- a/src/Core/Revision/Json/JsonMenuRenderer.php
+++ b/src/Core/Revision/Json/JsonMenuRenderer.php
@@ -149,7 +149,7 @@ final class JsonMenuRenderer implements RuntimeExtensionInterface
             case self::TYPE_VIEW:
                 return $this->revolveViewOptions($optionsResolver, $options);
             case self::TYPE_PREVIEW:
-                $options['actions'] = ['preview' => [], 'copy' => ['deny' => ['root']]];
+                $options['actions'] = ['preview' => [], 'copy' => ['deny' => ['_root']]];
                 $optionsResolver->setRequired(['structure']);
                 break;
             case self::TYPE_REVISION_EDIT:

--- a/src/Resources/views/revision/json/json_menu_nested.html.twig
+++ b/src/Resources/views/revision/json/json_menu_nested.html.twig
@@ -5,6 +5,7 @@
     {%- set item = def.menu -%}
     {%- set itemJson = { 'id': item.id, 'label': item.label, 'type': item.type, 'object': (item.object|merge({ 'label': item.label }))  } -%}
     {%- set node = def.getNodeByName(item.type) -%}
+
     <div id="json-menu-nested-{{ def.id }}-alerts" class="json-menu-nested-alerts"></div>
     <div id="json-menu-nested-{{ def.id }}"
          class="json-menu-nested json-menu-nested-item {{ def.isSortable ? 'json-menu-nested-sortable' }}"
@@ -20,19 +21,34 @@
         >
         <div class="json-menu-nested-loading"><i class="fa fa-cog fa-spin fa-3x fa-fw"></i></div>
         {%- if def.isSilentPublish -%}<input type="hidden" class="json-menu-nested-silent-publish" id="{{ def.id }}" />{%- endif -%}
-        {%- if 'add' in node.actions or 'copy' in node.actions or 'paste' in node.actions -%}
-            <span class="input-group-btn">
-                {% with { 'position': 'root' } %}
-                    {{ block('buttonAdd') }}
-                    {{ block('buttonMore') }}
-                {% endwith %}
-            </span>
-        {%- endif -%}
+
+        {{ block('renderRootActions') }}
+
         <ol class="json-menu-nested-list json-menu-nested-root" data-list="{{ item.id }}">
             {%- set level = level + 1 -%}
             {%- for item in item.children -%}{{ block('renderItem') }}{%- endfor -%}
         </ol>
     </div>
+{% endblock %}
+
+{% block renderRootActions %}
+    {%- if 'add' in node.actions or 'copy' in node.actions or 'paste' in node.actions -%}
+    <span class="input-group-btn">
+        {% with { 'position': 'root' } %}
+            {%- set buttons = {
+                'add': block('buttonAdd'),
+                'more': block('buttonMore'),
+            } -%}
+            {%- set blockRenderContext = { 'item': item, 'node': node, 'buttons': buttons } -%}
+            {%- set rootBlock = def.renderBlocks('item_action', blockRenderContext) -%}
+            {%- if rootBlock|length > 0 -%}
+                {%- for block in rootBlock %}{{ block|raw }}{%- endfor -%}
+            {%- else -%}
+                {%- for button in buttons -%}{{ button|raw }}{%- endfor -%}
+            {%- endif -%}
+        {% endwith %}
+    </span>
+    {%- endif -%}
 {% endblock %}
 
 {% block renderItem %}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |y|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

User should be able to add item of type even if they are not granted for adding other item types.
Also we can deny some fields for the user, but still allow edit/add on the item.

New feature, block template for overriding root actions

https://github.com/ems-project/EMSCommonBundle/pull/442/files