### PR TITLE
feat: revision versioning (options)

### DIFF
--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Revision;
 
 use EMS\CommonBundle\Common\Standard\Json;
-use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\Core\Revision\DraftInProgress;
 use EMS\CoreBundle\EMSCoreBundle;
@@ -105,10 +104,7 @@ class EditController extends AbstractController
         }
 
         $this->dataService->lockRevision($revision);
-
-        if (null === $contentType = $revision->getContentType()) {
-            throw new NotFoundException('ContentType not found!');
-        }
+        $contentType = $revision->giveContentType();
 
         if ($revision->hasEndTime() && !$this->isGranted(Roles::ROLE_SUPER)) {
             throw new ElasticmsException($this->translator->trans('log.data.revision.only_super_can_finalize_an_archive', LogRevisionContext::read($revision), EMSCoreBundle::TRANS_DOMAIN));

--- a/src/Core/ContentType/Version/VersionOptions.php
+++ b/src/Core/ContentType/Version/VersionOptions.php
@@ -13,6 +13,7 @@ class VersionOptions implements \ArrayAccess
     private array $options = [];
 
     public const DATES_READ_ONLY = 'dates_read_only';
+    public const ASK_VERSION_TAG = 'ask_version_tag';
 
     /**
      * @param array<string, bool> $data
@@ -20,6 +21,7 @@ class VersionOptions implements \ArrayAccess
     public function __construct(array $data)
     {
         $this->options[self::DATES_READ_ONLY] = $data[self::DATES_READ_ONLY] ?? true;
+        $this->options[self::ASK_VERSION_TAG] = $data[self::ASK_VERSION_TAG] ?? true;
     }
 
     /**

--- a/src/Core/ContentType/Version/VersionOptions.php
+++ b/src/Core/ContentType/Version/VersionOptions.php
@@ -13,6 +13,7 @@ class VersionOptions implements \ArrayAccess
     private array $options = [];
 
     public const DATES_READ_ONLY = 'dates_read_only';
+    public const DATES_INTERVAL_ONE_DAY = 'dates_interval_one_day';
     public const ASK_VERSION_TAG = 'ask_version_tag';
 
     /**
@@ -21,6 +22,7 @@ class VersionOptions implements \ArrayAccess
     public function __construct(array $data)
     {
         $this->options[self::DATES_READ_ONLY] = $data[self::DATES_READ_ONLY] ?? true;
+        $this->options[self::DATES_INTERVAL_ONE_DAY] = $data[self::DATES_INTERVAL_ONE_DAY] ?? false;
         $this->options[self::ASK_VERSION_TAG] = $data[self::ASK_VERSION_TAG] ?? true;
     }
 

--- a/src/Core/ContentType/Version/VersionOptions.php
+++ b/src/Core/ContentType/Version/VersionOptions.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType\Version;
+
+/**
+ * @implements \ArrayAccess<string, bool>
+ */
+class VersionOptions implements \ArrayAccess
+{
+    /** @var array<string, bool> */
+    private array $options = [];
+
+    public const DATES_READ_ONLY = 'dates_read_only';
+
+    /**
+     * @param array<string, bool> $data
+     */
+    public function __construct(array $data)
+    {
+        $this->options[self::DATES_READ_ONLY] = $data[self::DATES_READ_ONLY] ?? true;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->options[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->options[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->options[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->options[$offset]);
+    }
+}

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -5,6 +5,7 @@ namespace EMS\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use EMS\CoreBundle\Core\ContentType\Version\VersionOptions;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
 use EMS\CoreBundle\Entity\Helper\JsonDeserializer;
 use EMS\CoreBundle\Form\DataField\ContainerFieldType;
@@ -402,7 +403,14 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
      *
      * @ORM\Column(name="version_tags", type="json", nullable=true)
      */
-    protected $versionTags = [];
+    protected array $versionTags = [];
+
+    /**
+     * @var ?array<string, bool>
+     *
+     * @ORM\Column(name="version_options", type="json", nullable=true)
+     */
+    protected ?array $versionOptions = [];
 
     /**
      * @var string|null
@@ -1827,6 +1835,16 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
         $this->versionTags = $versionTags;
     }
 
+    public function getVersionOptions(): VersionOptions
+    {
+        return new VersionOptions($this->versionOptions ?? []);
+    }
+
+    public function setVersionOptions(VersionOptions $versionOptions): void
+    {
+        $this->versionOptions = $versionOptions->getOptions();
+    }
+
     public function getVersionDateFromField(): ?string
     {
         return $this->versionDateFromField;
@@ -1852,10 +1870,14 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
      */
     public function getDisabledDataFields(): array
     {
-        return \array_filter([
-            $this->getVersionDateFromField(),
-            $this->getVersionDateToField(),
-        ]);
+        if ($this->getVersionOptions()[VersionOptions::DATES_READ_ONLY]) {
+            return \array_filter([
+                $this->getVersionDateFromField(),
+                $this->getVersionDateToField(),
+            ]);
+        }
+
+        return [];
     }
 
     public function hasOwnerRole(): bool

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -150,6 +150,7 @@ class ContentTypeType extends AbstractType
                         'mapping' => $mapping,
                         'types' => ['date'],
                     ])
+                    ->add('versionOptions', ContentTypeVersionOptionsType::class)
                     ->add('versionTags', CollectionType::class, [
                         'entry_type' => TextType::class,
                         'attr' => [

--- a/src/Form/Form/ContentTypeVersionOptionsType.php
+++ b/src/Form/Form/ContentTypeVersionOptionsType.php
@@ -19,6 +19,7 @@ class ContentTypeVersionOptionsType extends AbstractType
     {
         $builder
             ->add(VersionOptions::DATES_READ_ONLY, CheckboxType::class, ['required' => false])
+            ->add(VersionOptions::DATES_INTERVAL_ONE_DAY, CheckboxType::class, ['required' => false])
             ->add(VersionOptions::ASK_VERSION_TAG, CheckboxType::class, ['required' => false])
         ;
     }

--- a/src/Form/Form/ContentTypeVersionOptionsType.php
+++ b/src/Form/Form/ContentTypeVersionOptionsType.php
@@ -19,6 +19,7 @@ class ContentTypeVersionOptionsType extends AbstractType
     {
         $builder
             ->add(VersionOptions::DATES_READ_ONLY, CheckboxType::class, ['required' => false])
+            ->add(VersionOptions::ASK_VERSION_TAG, CheckboxType::class, ['required' => false])
         ;
     }
 }

--- a/src/Form/Form/ContentTypeVersionOptionsType.php
+++ b/src/Form/Form/ContentTypeVersionOptionsType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Form\Form;
+
+use EMS\CoreBundle\Core\ContentType\Version\VersionOptions;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ContentTypeVersionOptionsType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface<FormBuilderInterface> $builder
+     * @param array<string, mixed>                       $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(VersionOptions::DATES_READ_ONLY, CheckboxType::class, ['required' => false])
+        ;
+    }
+}

--- a/src/Form/Form/RevisionType.php
+++ b/src/Form/Form/RevisionType.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Form\Form;
 
+use EMS\CoreBundle\Core\ContentType\Version\VersionOptions;
 use EMS\CoreBundle\DependencyInjection\EMSCoreExtension;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
@@ -104,8 +105,9 @@ class RevisionType extends AbstractType
         if (null !== $revision && $revision->getDraft()) {
             $contentType = $revision->getContentType();
             $environment = $contentType ? $contentType->getEnvironment() : null;
+            $askVersionTags = $contentType && $contentType->getVersionOptions()[VersionOptions::ASK_VERSION_TAG];
 
-            if (null !== $environment && null !== $contentType && $contentType->hasVersionTags()) {
+            if (null !== $environment && $askVersionTags) {
                 $builder
                     ->add('publish_version_tags', ChoiceType::class, [
                         'translation_domain' => false,

--- a/src/Form/Form/RevisionType.php
+++ b/src/Form/Form/RevisionType.php
@@ -10,6 +10,7 @@ use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldModelTransformer;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldViewTransformer;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
+use EMS\CoreBundle\Validator\Constraints\RevisionRawData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -41,13 +42,14 @@ class RevisionType extends AbstractType
         }
 
         $builder->add('data', $contentType->getFieldType()->getType(), [
-                'metadata' => $contentType->getFieldType(),
-                'error_bubbling' => false,
-                'migration' => $options['migration'],
-                'with_warning' => $options['with_warning'],
-                'raw_data' => $options['raw_data'],
-                'disabled_fields' => $contentType->getDisabledDataFields(),
-                'referrer-ems-id' => $revision && $revision->hasOuuid() ? $revision->getEmsId() : null,
+            'constraints' => [new RevisionRawData(['contentType' => $contentType])],
+            'metadata' => $contentType->getFieldType(),
+            'error_bubbling' => false,
+            'migration' => $options['migration'],
+            'with_warning' => $options['with_warning'],
+            'raw_data' => $options['raw_data'],
+            'disabled_fields' => $contentType->getDisabledDataFields(),
+            'referrer-ems-id' => $revision && $revision->hasOuuid() ? $revision->getEmsId() : null,
         ]);
 
         if ($revision) {

--- a/src/Resources/DoctrineMigrations/pdo_mysql/Version20220922092018.php
+++ b/src/Resources/DoctrineMigrations/pdo_mysql/Version20220922092018.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220922092018 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type ADD version_options LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type DROP version_options');
+    }
+}

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20220922073351.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20220922073351.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220922073351 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type ADD version_options JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type DROP version_options');
+    }
+}

--- a/src/Resources/translations/validators.en.yml
+++ b/src/Resources/translations/validators.en.yml
@@ -1,3 +1,9 @@
+revision:
+  raw_data:
+    version_from_required: 'This Field is not valid! Empty field'
+    version_to_invalid: 'Should be greater then "%fromField%"'
+
+
 user:
   username:
     already_used: 'The username is already used.'

--- a/src/Resources/translations/validators.en.yml
+++ b/src/Resources/translations/validators.en.yml
@@ -1,7 +1,8 @@
 revision:
   raw_data:
     version_from_required: 'This Field is not valid! Empty field'
-    version_to_invalid: 'Should be greater then "%fromField%"'
+    version_to_greater: 'Should be greater then "%fromField%"'
+    version_to_greater_one_day: 'Should be at least 1 day greater then "%fromField%"'
 
 
 user:

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -126,6 +126,9 @@
                                         <div class="col-md-6">{{ form_row(form.versionDateFromField) }}</div>
                                         <div class="col-md-6">{{ form_row(form.versionDateToField) }}</div>
                                         <div class="col-md-12">
+                                            {{ form_row(form.versionOptions) }}
+                                        </div>
+                                        <div class="col-md-12">
                                             {{ form_row(form.versionTags) }}
                                         </div>
                                     </div>

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -125,12 +125,8 @@
                                     <div class="row">
                                         <div class="col-md-6">{{ form_row(form.versionDateFromField) }}</div>
                                         <div class="col-md-6">{{ form_row(form.versionDateToField) }}</div>
-                                        <div class="col-md-12">
-                                            {{ form_row(form.versionOptions) }}
-                                        </div>
-                                        <div class="col-md-12">
-                                            {{ form_row(form.versionTags) }}
-                                        </div>
+                                        <div class="col-md-6">{{ form_row(form.versionTags) }}</div>
+                                        <div class="col-md-6">{{ form_row(form.versionOptions) }}</div>
                                     </div>
                                 </div>
                             {% endif %}

--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -231,7 +231,7 @@
 					{{ 'views.data.revisions-data-html.previous-revision'|trans({'%timestamp%': revision.created|date(date_time_format)}) }}
 				{% endif %}
 			</h3>
-			{% if revision.hasVersionTag and revision.versionDate('to') != null %}
+			{% if revision.hasVersionTag and revision.versionDate('to') != null and latestVersion %}
 				<div class="box-tools pull-right">
 					<a href="{{ path('emsco_view_revisions', {'type': latestVersion.contentTypeName, 'ouuid': latestVersion.ouuid }) }}" class="btn btn-default bg-{{ revision.contentType.color  }} btn-sm">
 						<i class="{% if revision.contentType.icon %}{{ revision.contentType.icon }} {% else %} fa fa-question {% endif %}"></i>

--- a/src/Validator/Constraints/RevisionRawData.php
+++ b/src/Validator/Constraints/RevisionRawData.php
@@ -12,7 +12,8 @@ class RevisionRawData extends Constraint
     public ContentType $contentType;
 
     public string $versionFromRequired = 'revision.raw_data.version_from_required';
-    public string $versionToInvalid = 'revision.raw_data.version_to_invalid';
+    public string $versionToGreater = 'revision.raw_data.version_to_greater';
+    public string $versionToGreaterOneDay = 'revision.raw_data.version_to_greater_one_day';
 
     public function getRequiredOptions(): array
     {

--- a/src/Validator/Constraints/RevisionRawData.php
+++ b/src/Validator/Constraints/RevisionRawData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Validator\Constraints;
+
+use EMS\CoreBundle\Entity\ContentType;
+use Symfony\Component\Validator\Constraint;
+
+class RevisionRawData extends Constraint
+{
+    public ContentType $contentType;
+
+    public string $versionFromRequired = 'revision.raw_data.version_from_required';
+    public string $versionToInvalid = 'revision.raw_data.version_to_invalid';
+
+    public function getRequiredOptions(): array
+    {
+        return ['contentType'];
+    }
+}

--- a/src/Validator/Constraints/RevisionRawDataValidator.php
+++ b/src/Validator/Constraints/RevisionRawDataValidator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Validator\Constraints;
+
+use EMS\Helpers\Standard\DateTime;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class RevisionRawDataValidator extends ConstraintValidator
+{
+    /**
+     * @param array<string, mixed> $value
+     * @param RevisionRawData      $constraint
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if ($constraint->contentType->hasVersionTags()) {
+            $this->validateVersionDates($constraint, $value);
+        }
+    }
+
+    /**
+     * @param RevisionRawData      $constraint
+     * @param array<string, mixed> $rawData
+     */
+    private function validateVersionDates(Constraint $constraint, array $rawData): void
+    {
+        $contentType = $constraint->contentType;
+
+        $fromField = $contentType->getVersionDateFromField();
+        $versionFromDate = $this->getVersionDateFromRawData($rawData, $fromField);
+
+        if (null === $versionFromDate) {
+            $this->context
+                ->buildViolation($constraint->versionFromRequired)
+                ->atPath(\sprintf('[%s]', $fromField))
+                ->addViolation();
+        }
+
+        $toField = $contentType->getVersionDateToField();
+        $versionToDate = $this->getVersionDateFromRawData($rawData, $toField);
+
+        if ($fromField && $versionToDate && $versionToDate < $versionFromDate) {
+            $formFieldType = $contentType->getFieldType()->findChildByName($fromField);
+            $formFieldLabel = $formFieldType ? $formFieldType->getDisplayOption('label', $fromField) : $fromField;
+
+            $this->context
+                ->buildViolation($constraint->versionToInvalid)
+                ->setParameter('%fromField%', $formFieldLabel)
+                ->atPath(\sprintf('[%s]', $toField))
+                ->addViolation();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $rawData
+     */
+    private function getVersionDateFromRawData(array $rawData, ?string $field): ?\DateTimeInterface
+    {
+        if (null === $field || !isset($rawData[$field])) {
+            return null;
+        }
+
+        return DateTime::createFromFormat($rawData[$field]);
+    }
+}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

- Fixed the latest version (without end date) can be missing.
- Add a new options variable on content type -> versionOptions
- New version option `dates_read_only` (default true). 
- New version option `ask_version_tag` (default true). Gives the possibility to not show version selection modal.
- New version option `dates_interval_one_day`. Project not looking at version times, end date should be at least one day greater then from date.
- Add rawData validator for checking version defined options.