### PR TITLE
fix: use correct class name for forward, form type, join qb

### DIFF
--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -117,7 +117,7 @@ class DataController extends AbstractController
         ]);
         /** @var Search $search */
         foreach ($searches as $search) {
-            return $this->forward('EMSCoreBundle:Elasticsearch:search', [
+            return $this->forward('EMS\CoreBundle\Controller\ElasticsearchController::searchAction', [
                 'query' => null,
             ], [
                 'search_form' => $search->jsonSerialize(),
@@ -194,7 +194,7 @@ class DataController extends AbstractController
             throw new \RuntimeException('Unexpected null json');
         }
 
-        return $this->forward('EMSCoreBundle:Elasticsearch:search', [
+        return $this->forward('EMS\CoreBundle\Controller\ElasticsearchController::searchAction', [
             'query' => null,
         ], [
             'search_form' => \json_decode($formEncoded, true),

--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -257,7 +257,7 @@ class ElasticsearchController extends AbstractController
             }
         }
 
-        return $this->forward('EMSCoreBundle:Elasticsearch:search', [
+        return $this->forward('EMS\CoreBundle\Controller\ElasticsearchController::searchAction', [
             'query' => null,
         ], [
             'search_form' => $search->jsonSerialize(),

--- a/src/Controller/Views/CriteriaController.php
+++ b/src/Controller/Views/CriteriaController.php
@@ -206,7 +206,7 @@ class CriteriaController extends AbstractController
         \sleep(2);
         $this->elasticaService->getClusterHealth('green', '20s');
 
-        return $this->forward('EMSCoreBundle:Views\Criteria:generateCriteriaTable', ['view' => $view]);
+        return $this->forward('EMS\CoreBundle\Controller\Views\CriteriaController:generateCriteriaTable', ['view' => $view]);
     }
 
     private function isAuthorized(FieldType $criteriaField, AuthorizationCheckerInterface $security): bool

--- a/src/Form/Form/NotificationFormType.php
+++ b/src/Form/Form/NotificationFormType.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Form\Form;
 
 use Doctrine\ORM\EntityRepository;
 use EMS\CoreBundle\EMSCoreBundle;
+use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Template;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
 use EMS\CoreBundle\Service\EnvironmentService;
@@ -28,7 +29,7 @@ class NotificationFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('template', EntityType::class, [
-            'class' => 'EMSCoreBundle:Template',
+            'class' => Template::class,
             'translation_domain' => EMSCoreBundle::TRANS_DOMAIN,
             'query_builder' => function (EntityRepository $er) {
                 return $er->createQueryBuilder('t')
@@ -73,7 +74,7 @@ class NotificationFormType extends AbstractType
                 },
         ])
         ->add('contentType', EntityType::class, [
-                'class' => 'EMSCoreBundle:ContentType',
+                'class' => ContentType::class,
                 'translation_domain' => EMSCoreBundle::TRANS_DOMAIN,
                 'query_builder' => function (EntityRepository $er) {
                     return $er->createQueryBuilder('ct')

--- a/src/Form/Form/UserType.php
+++ b/src/Form/Form/UserType.php
@@ -7,6 +7,7 @@ namespace EMS\CoreBundle\Form\Form;
 use Doctrine\ORM\EntityRepository;
 use EMS\CoreBundle\EMSCoreBundle;
 use EMS\CoreBundle\Entity\User;
+use EMS\CoreBundle\Entity\WysiwygProfile;
 use EMS\CoreBundle\Form\Field\CodeEditorType;
 use EMS\CoreBundle\Form\Field\ObjectPickerType;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
@@ -83,7 +84,7 @@ final class UserType extends AbstractType
             ->add('wysiwygProfile', EntityType::class, [
                 'required' => false,
                 'label' => 'WYSIWYG profile',
-                'class' => 'EMSCoreBundle:WysiwygProfile',
+                'class' => WysiwygProfile::class,
                 'choice_label' => 'name',
                 'query_builder' => function (EntityRepository $er) {
                     return $er->createQueryBuilder('p')->orderBy('p.orderKey', 'ASC');

--- a/src/Form/User/UserProfileType.php
+++ b/src/Form/User/UserProfileType.php
@@ -7,6 +7,7 @@ namespace EMS\CoreBundle\Form\User;
 use Doctrine\ORM\EntityRepository;
 use EMS\CoreBundle\EMSCoreBundle;
 use EMS\CoreBundle\Entity\User;
+use EMS\CoreBundle\Entity\WysiwygProfile;
 use EMS\CoreBundle\Form\Field\CodeEditorType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -69,7 +70,7 @@ class UserProfileType extends AbstractType
             ->add('wysiwygProfile', EntityType::class, [
                 'required' => false,
                 'label' => 'user.wysiwyg_profile',
-                'class' => 'EMSCoreBundle:WysiwygProfile',
+                'class' => WysiwygProfile::class,
                 'choice_label' => 'name',
                 'query_builder' => function (EntityRepository $er) {
                     return $er->createQueryBuilder('p')->orderBy('p.orderKey', 'ASC');

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -34,7 +34,7 @@ class NotificationRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('n')
             ->select('n')
-            ->join('EMSCoreBundle:Revision', 'r', 'WITH', 'n.revision = r.id')
+            ->join('n.revision', 'r', 'WITH', 'n.revision = r.id')
             ->where('r.ouuid = :ouuid')
             ->andWhere('r.contentType = :contentType')
             ->andwhere('r.deleted = :false')
@@ -100,7 +100,7 @@ class NotificationRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('n')
         ->select('count(n)')
-        ->join('EMSCoreBundle:Revision', 'r', 'WITH', 'n.revision = r.id')
+        ->join('n.revision', 'r', 'WITH', 'n.revision = r.id')
         ->where('n.status = :status')
         ->andWhere('r.contentType = :contentType')
         ->andwhere('r.ouuid = :ouuid');


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Example of bug:

The controller for URI "/data/example" is not callable: Controller "EMSCoreBundle:Elasticsearch:search" does neither exist as service nor as class.

https://symfony.com/doc/5.4/controller/forwarding.html