### PR TITLE
fix: version dates in container

### DIFF
--- a/src/Entity/FieldType.php
+++ b/src/Entity/FieldType.php
@@ -654,6 +654,16 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
         return $this->children;
     }
 
+    public function getPath(): string
+    {
+        if (null !== $parent = $this->getParent()) {
+            $path = [\sprintf('[%s]', $this->getName())];
+            \array_unshift($path, $parent->getPath());
+        }
+
+        return \implode('', $path ?? []);
+    }
+
     public function findChildByName(string $name): ?FieldType
     {
         foreach ($this->loopChildren() as $child) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The version dates can be inside a container. We should use the new ArrayHelper for getting the value from the rawData.
Added a new method on `FieldType` get path, which will return the nested path for attaching the violation at the correct place.

A field type name must be unique inside a structure, but this a contentType rule.
