### PR TITLE
fix: revision task current nullable

### DIFF
--- a/src/Entity/RevisionTaskTrait.php
+++ b/src/Entity/RevisionTaskTrait.php
@@ -12,7 +12,7 @@ trait RevisionTaskTrait
      * @ORM\ManyToOne(targetEntity="EMS\CoreBundle\Entity\Task")
      * @ORM\JoinColumn(name="task_current_id", referencedColumnName="id", nullable=true)
      */
-    private ?Task $taskCurrent;
+    private ?Task $taskCurrent = null;
 
     /**
      * @var string[]|null


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Php error, accessing $taskCurrent without default value