### PR TITLE
fix(500): edit the main container

### DIFF
--- a/src/Resources/views/form/fields.html.twig
+++ b/src/Resources/views/form/fields.html.twig
@@ -1385,7 +1385,7 @@
         {{- form_widget(form.options, {'seed': form.vars.id, 'editSubfields': false} ) -}}
     {% endif %}
 
-	{% if form.vars.data.children is defined and form.vars.data.children|filter(child => not child.deleted)|length > 0 %}
+	{% if form.rendered == false and form.vars.data.children is defined and form.vars.data.children|filter(child => not child.deleted)|length > 0 %}
 		<ul class="list-group" id="{{ form.vars.id }}_list_container">
 			{{- form_widget(form) -}}
 		</ul>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

An exception has been thrown during the rendering of a template ("Field "fieldType" has already been rendered, save the result of previous render call to a variable and output that instead.").