### PR TITLE
fix(contentType): search link display (external env)

### DIFF
--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -245,6 +245,10 @@ class ContentTypeType extends AbstractType
         $builder->add('rootContentType');
         $builder->add('viewRole', RolePickerType::class);
 
+        $builder->add('searchLinkDisplayRole', RolePickerType::class, [
+            'label' => 'Display the search link in main navigation',
+        ]);
+
         if ($environment->getManaged()) {
             $builder->add('defaultValue', CodeEditorType::class, [
                 'required' => false,
@@ -260,9 +264,6 @@ class ContentTypeType extends AbstractType
             $builder->add('trashRole', RolePickerType::class);
             $builder->add('ownerRole', RolePickerType::class);
 
-            $builder->add('searchLinkDisplayRole', RolePickerType::class, [
-                'label' => 'Display the search link in main navigation',
-            ]);
             $builder->add('createLinkDisplayRole', RolePickerType::class, [
                 'label' => 'Display the creation link in main navigation',
             ]);

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -43,9 +43,9 @@
                             {{ form_row(form.deleteRole) }}
                             {{ form_row(form.trashRole) }}
                             {{ form_row(form.ownerRole) }}
-                            {{ form_row(form.searchLinkDisplayRole) }}
                             {{ form_row(form.createLinkDisplayRole) }}
                         {% endif %}
+                        {{ form_row(form.searchLinkDisplayRole) }}
                         {{ form_row(form.icon) }}
                         {{ form_row(form.color) }}
                         {{ form_row(form.refererFieldName) }}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

We should also be able to disable the 'old' search for external environments (referenced contentTypes)