### PR TITLE
fix(view): role not required

### DIFF
--- a/src/Entity/View.php
+++ b/src/Entity/View.php
@@ -189,7 +189,7 @@ class View extends JsonDeserializer implements \JsonSerializable, EntityInterfac
         return $this->role;
     }
 
-    public function setRole(string $role): void
+    public function setRole(?string $role): void
     {
         $this->role = $role;
     }

--- a/src/Form/Form/ViewType.php
+++ b/src/Form/Form/ViewType.php
@@ -55,6 +55,7 @@ class ViewType extends AbstractType
             ],
         ])
         ->add('role', RolePickerType::class, [
+            'required' => false,
             'row_attr' => [
                 'class' => 'col-md-4',
             ],


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Updating old views will set role to "Not defined" and it will not show up in the menu anymore. If you do not want role checking you leave role blank on the view.