### PR TITLE
fix(json-nested): custom blocks not working in 4.0

### DIFF
--- a/src/Core/Revision/Json/JsonMenuNestedDefinition.php
+++ b/src/Core/Revision/Json/JsonMenuNestedDefinition.php
@@ -149,8 +149,8 @@ final class JsonMenuNestedDefinition
                 continue;
             }
 
-            if (isset($block['html']) && \is_string($block['html'])) {
-                $results[] = $this->twig->createTemplate($block['html'])->render($context);
+            if (isset($block['html'])) {
+                $results[] = $this->twig->createTemplate((string) $block['html'])->render($context);
             }
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Custom block rendering for JsonMenuNested broken with 4.0 migration.
The 'html' is \Twig_markup or a string. Solution cast to string