### PR TITLE
refactor(contentType): create roles json plus migration

### DIFF
--- a/src/Controller/ContentManagement/ContentTypeController.php
+++ b/src/Controller/ContentManagement/ContentTypeController.php
@@ -243,7 +243,6 @@ class ContentTypeController extends AbstractController
             } else {
                 $contentType = $contentTypeAdded;
                 $contentType->setAskForOuuid(false);
-                $contentType->setEditRole('ROLE_AUTHOR');
                 $contentType->setOrderKey($contentTypeRepository->nextOrderKey());
                 $em->persist($contentType);
             }

--- a/src/Controller/ContentManagement/ContentTypeController.php
+++ b/src/Controller/ContentManagement/ContentTypeController.php
@@ -243,7 +243,6 @@ class ContentTypeController extends AbstractController
             } else {
                 $contentType = $contentTypeAdded;
                 $contentType->setAskForOuuid(false);
-                $contentType->setViewRole('ROLE_AUTHOR');
                 $contentType->setEditRole('ROLE_AUTHOR');
                 $contentType->setCreateRole('ROLE_AUTHOR');
                 $contentType->setOrderKey($contentTypeRepository->nextOrderKey());

--- a/src/Controller/ContentManagement/ContentTypeController.php
+++ b/src/Controller/ContentManagement/ContentTypeController.php
@@ -244,7 +244,6 @@ class ContentTypeController extends AbstractController
                 $contentType = $contentTypeAdded;
                 $contentType->setAskForOuuid(false);
                 $contentType->setEditRole('ROLE_AUTHOR');
-                $contentType->setCreateRole('ROLE_AUTHOR');
                 $contentType->setOrderKey($contentTypeRepository->nextOrderKey());
                 $em->persist($contentType);
             }

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -204,6 +204,10 @@ class DataController extends AbstractController
 
     public function trashAction(ContentType $contentType): Response
     {
+        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::TRASH])) {
+            throw $this->createAccessDeniedException('Trash not granted!');
+        }
+
         return $this->render('@EMSCore/data/trash.html.twig', [
             'contentType' => $contentType,
             'revisions' => $this->dataService->getAllDeleted($contentType),

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -378,9 +378,8 @@ class DataController extends AbstractController
     {
         $revision = $this->dataService->getNewestRevision($type, $ouuid);
         $contentType = $revision->giveContentType();
-        $deleteRole = $contentType->getRoles()[ContentTypeRoles::DELETE] ?? null;
 
-        if ($deleteRole && !$this->isGranted($deleteRole)) {
+        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::DELETE])) {
             throw $this->createAccessDeniedException('Delete not granted!');
         }
 

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -204,7 +204,7 @@ class DataController extends AbstractController
 
     public function trashAction(ContentType $contentType): Response
     {
-        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::TRASH])) {
+        if (!$this->isGranted($contentType->role(ContentTypeRoles::TRASH))) {
             throw $this->createAccessDeniedException('Trash not granted!');
         }
 
@@ -383,7 +383,7 @@ class DataController extends AbstractController
         $revision = $this->dataService->getNewestRevision($type, $ouuid);
         $contentType = $revision->giveContentType();
 
-        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::DELETE])) {
+        if (!$this->isGranted($contentType->role(ContentTypeRoles::DELETE))) {
             throw $this->createAccessDeniedException('Delete not granted!');
         }
 
@@ -941,7 +941,7 @@ class DataController extends AbstractController
 
     public function addAction(ContentType $contentType, Request $request): Response
     {
-        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::CREATE])) {
+        if (!$this->isGranted($contentType->role(ContentTypeRoles::CREATE))) {
             throw $this->createAccessDeniedException('Create not granted');
         }
 

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -8,6 +8,7 @@ use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\Pdf\Pdf;
 use EMS\CommonBundle\Service\Pdf\PdfPrinterInterface;
 use EMS\CommonBundle\Service\Pdf\PdfPrintOptions;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\ContentType\ViewTypes;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\EMSCoreBundle;
@@ -377,7 +378,7 @@ class DataController extends AbstractController
     {
         $revision = $this->dataService->getNewestRevision($type, $ouuid);
         $contentType = $revision->giveContentType();
-        $deleteRole = $contentType->getDeleteRole();
+        $deleteRole = $contentType->getRoles()[ContentTypeRoles::DELETE] ?? null;
 
         if ($deleteRole && !$this->isGranted($deleteRole)) {
             throw $this->createAccessDeniedException('Delete not granted!');

--- a/src/Controller/ContentManagement/DataController.php
+++ b/src/Controller/ContentManagement/DataController.php
@@ -941,6 +941,10 @@ class DataController extends AbstractController
 
     public function addAction(ContentType $contentType, Request $request): Response
     {
+        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::CREATE])) {
+            throw $this->createAccessDeniedException('Create not granted');
+        }
+
         $this->dataService->hasCreateRights($contentType);
 
         $revision = new Revision();

--- a/src/Controller/ContentManagement/EnvironmentController.php
+++ b/src/Controller/ContentManagement/EnvironmentController.php
@@ -7,6 +7,7 @@ use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use EMS\CommonBundle\Common\Standard\Type;
 use EMS\CommonBundle\Elasticsearch\Exception\NotFoundException;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\EMSCoreBundle;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
@@ -141,7 +142,7 @@ class EnvironmentController extends AbstractController
                             break;
                         }
 
-                        if (!$this->authorizationChecker->isGranted($revision->giveContentType()->getPublishRole())) {
+                        if (!$this->authorizationChecker->isGranted($revision->giveContentType()->role(ContentTypeRoles::PUBLISH))) {
                             $this->logger->warning('log.environment.dont_have_publish_role', [
                                 EmsFields::LOG_ENVIRONMENT_FIELD => $env,
                                 EmsFields::LOG_CONTENTTYPE_FIELD => $revision->getContentType(),

--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Revision;
 
 use EMS\CommonBundle\Common\Standard\Json;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\Core\Revision\DraftInProgress;
 use EMS\CoreBundle\EMSCoreBundle;
@@ -316,8 +317,8 @@ class EditController extends AbstractController
     public function archiveRevision(Revision $revision): Response
     {
         $contentType = $revision->giveContentType();
-        $archiveRole = $contentType->getArchiveRole();
-        if (null === $archiveRole || !$this->isGranted($archiveRole)) {
+
+        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::ARCHIVE])) {
             throw $this->createAccessDeniedException('Archive not granted!');
         }
         if ($revision->hasEndTime()) {

--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -318,7 +318,7 @@ class EditController extends AbstractController
     {
         $contentType = $revision->giveContentType();
 
-        if (!$this->isGranted($contentType->getRoles()[ContentTypeRoles::ARCHIVE])) {
+        if (!$this->isGranted($contentType->role(ContentTypeRoles::ARCHIVE))) {
             throw $this->createAccessDeniedException('Archive not granted!');
         }
         if ($revision->hasEndTime()) {

--- a/src/Controller/Revision/EditController.php
+++ b/src/Controller/Revision/EditController.php
@@ -61,7 +61,7 @@ class EditController extends AbstractController
 
     public function editJsonRevision(Revision $revision, Request $request): Response
     {
-        if (!$this->isGranted($revision->giveContentType()->getEditRole())) {
+        if (!$this->isGranted($revision->giveContentType()->role(ContentTypeRoles::EDIT))) {
             throw new AccessDeniedException($request->getPathInfo());
         }
         if (!$revision->getDraft()) {

--- a/src/Controller/Revision/TaskController.php
+++ b/src/Controller/Revision/TaskController.php
@@ -259,7 +259,7 @@ final class TaskController extends AbstractController
         ]);
         $form->add('new_owner', SelectUserPropertyType::class, [
             'constraints' => [new NotBlank()],
-            'user_roles' => [$contentType->getRoles()[ContentTypeRoles::OWNER]],
+            'user_roles' => [$contentType->role(ContentTypeRoles::OWNER)],
             'exclude_values' => $revision->hasOwner() ? [$revision->getOwner()] : [],
             'placeholder' => '',
             'label' => 'task.change_owner.change',

--- a/src/Controller/Revision/TaskController.php
+++ b/src/Controller/Revision/TaskController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Revision;
 
 use EMS\CommonBundle\Common\Standard\Json;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\DataTable\TableExporter;
 use EMS\CoreBundle\Core\Revision\Task\TaskDTO;
 use EMS\CoreBundle\Core\Revision\Task\TaskManager;
@@ -258,7 +259,7 @@ final class TaskController extends AbstractController
         ]);
         $form->add('new_owner', SelectUserPropertyType::class, [
             'constraints' => [new NotBlank()],
-            'user_roles' => [$contentType->getOwnerRole()],
+            'user_roles' => [$contentType->getRoles()[ContentTypeRoles::OWNER]],
             'exclude_values' => $revision->hasOwner() ? [$revision->getOwner()] : [],
             'placeholder' => '',
             'label' => 'task.change_owner.change',

--- a/src/Controller/Views/CriteriaController.php
+++ b/src/Controller/Views/CriteriaController.php
@@ -8,6 +8,7 @@ use EMS\CommonBundle\Elasticsearch\Response\Response as EmsResponse;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Entity\Form\CriteriaUpdateConfig;
@@ -293,7 +294,7 @@ class CriteriaController extends AbstractController
         $fieldPaths = \preg_split('/\\r\\n|\\r|\\n/', $view->getOptions()['criteriaFieldPaths']);
         $fieldPaths = \is_array($fieldPaths) ? $fieldPaths : [];
 
-        $authorized = $this->isAuthorized($criteriaField, $this->authorizationChecker) && $this->authorizationChecker->isGranted($view->getContentType()->getEditRole());
+        $authorized = $this->isAuthorized($criteriaField, $this->authorizationChecker) && $this->authorizationChecker->isGranted($view->getContentType()->role(ContentTypeRoles::EDIT));
 
         foreach ($fieldPaths as $path) {
             /** @var false|FieldType $child */
@@ -513,7 +514,7 @@ class CriteriaController extends AbstractController
                 throw new \RuntimeException('Unexpected revision type');
             }
 
-            $authorized = $this->authorizationChecker->isGranted($view->getContentType()->getEditRole());
+            $authorized = $this->authorizationChecker->isGranted($view->getContentType()->role(ContentTypeRoles::EDIT));
             if (!$authorized) {
                 $this->logger->warning('log.view.criteria.update_privilege_issue', [
                     EmsFields::LOG_CONTENTTYPE_FIELD => $revision->giveContentType()->getName(),

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -14,12 +14,14 @@ class ContentTypeRoles implements \ArrayAccess
     /** @var array<string, string> */
     private array $roles = [];
 
+    public const ARCHIVE = 'archive';
     public const VIEW = 'view';
     public const DELETE = 'delete';
     public const SHOW_LINK_CREATE = 'show_link_create';
     public const SHOW_LINK_SEARCH = 'show_link_search';
 
     private const TYPES = [
+        self::ARCHIVE,
         self::VIEW,
         self::DELETE,
         self::SHOW_LINK_CREATE,

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -17,6 +17,7 @@ class ContentTypeRoles implements \ArrayAccess
     public const ARCHIVE = 'archive';
     public const VIEW = 'view';
     public const DELETE = 'delete';
+    public const TRASH = 'trash';
     public const SHOW_LINK_CREATE = 'show_link_create';
     public const SHOW_LINK_SEARCH = 'show_link_search';
 
@@ -24,6 +25,7 @@ class ContentTypeRoles implements \ArrayAccess
         self::ARCHIVE,
         self::VIEW,
         self::DELETE,
+        self::TRASH,
         self::SHOW_LINK_CREATE,
         self::SHOW_LINK_SEARCH,
     ];

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -14,18 +14,20 @@ class ContentTypeRoles implements \ArrayAccess
     /** @var array<string, string> */
     private array $roles = [];
 
-    public const ARCHIVE = 'archive';
     public const VIEW = 'view';
+    public const CREATE = 'create';
     public const DELETE = 'delete';
     public const TRASH = 'trash';
+    public const ARCHIVE = 'archive';
     public const SHOW_LINK_CREATE = 'show_link_create';
     public const SHOW_LINK_SEARCH = 'show_link_search';
 
     private const TYPES = [
-        self::ARCHIVE,
         self::VIEW,
+        self::CREATE,
         self::DELETE,
         self::TRASH,
+        self::ARCHIVE,
         self::SHOW_LINK_CREATE,
         self::SHOW_LINK_SEARCH,
     ];
@@ -44,6 +46,7 @@ class ContentTypeRoles implements \ArrayAccess
     {
         switch ($type) {
             case self::VIEW:
+            case self::CREATE:
                 return Roles::ROLE_AUTHOR;
             case self::SHOW_LINK_SEARCH:
             case self::SHOW_LINK_CREATE:

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Core\ContentType;
 
+use EMS\CoreBundle\Roles;
+
 /**
  * @implements \ArrayAccess<string, string>
  */
@@ -12,11 +14,13 @@ class ContentTypeRoles implements \ArrayAccess
     /** @var array<string, string> */
     private array $roles = [];
 
+    public const VIEW = 'view';
     public const DELETE = 'delete';
     public const SHOW_LINK_CREATE = 'show_link_create';
     public const SHOW_LINK_SEARCH = 'show_link_search';
 
     private const TYPES = [
+        self::VIEW,
         self::DELETE,
         self::SHOW_LINK_CREATE,
         self::SHOW_LINK_SEARCH,
@@ -28,12 +32,20 @@ class ContentTypeRoles implements \ArrayAccess
     public function __construct(array $data)
     {
         foreach (self::TYPES as $type) {
-            $default = 'not-defined';
-            if (\in_array($type, [self::SHOW_LINK_CREATE, self::SHOW_LINK_SEARCH])) {
-                $default = 'ROLE_USER';
-            }
+            $this->roles[$type] = $data[$type] ?? $this->getDefaultValue($type);
+        }
+    }
 
-            $this->roles[$type] = $data[$type] ?? $default;
+    private function getDefaultValue(string $type): string
+    {
+        switch ($type) {
+            case self::VIEW:
+                return Roles::ROLE_AUTHOR;
+            case self::SHOW_LINK_SEARCH:
+            case self::SHOW_LINK_CREATE:
+                return Roles::ROLE_USER;
+            default:
+                return 'not-defined';
         }
     }
 

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType;
+
+/**
+ * @implements \ArrayAccess<string, ?string>
+ */
+class ContentTypeRoles implements \ArrayAccess
+{
+    /** @var array<string, ?string> */
+    private array $roles = [];
+
+    public const DELETE = 'delete';
+
+    private const TYPES = [self::DELETE];
+
+    /**
+     * @param array<string, ?string> $data
+     */
+    public function __construct(array $data)
+    {
+        foreach (self::TYPES as $type) {
+            $this->roles[$type] = $data[$type] ?? null;
+        }
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->roles[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->roles[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->roles[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->roles[$offset]);
+    }
+}

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -5,29 +5,40 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Core\ContentType;
 
 /**
- * @implements \ArrayAccess<string, ?string>
+ * @implements \ArrayAccess<string, string>
  */
 class ContentTypeRoles implements \ArrayAccess
 {
-    /** @var array<string, ?string> */
+    /** @var array<string, string> */
     private array $roles = [];
 
     public const DELETE = 'delete';
+    public const SHOW_LINK_CREATE = 'show_link_create';
+    public const SHOW_LINK_SEARCH = 'show_link_search';
 
-    private const TYPES = [self::DELETE];
+    private const TYPES = [
+        self::DELETE,
+        self::SHOW_LINK_CREATE,
+        self::SHOW_LINK_SEARCH,
+    ];
 
     /**
-     * @param array<string, ?string> $data
+     * @param array<string, string> $data
      */
     public function __construct(array $data)
     {
         foreach (self::TYPES as $type) {
-            $this->roles[$type] = $data[$type] ?? null;
+            $default = 'not-defined';
+            if (\in_array($type, [self::SHOW_LINK_CREATE, self::SHOW_LINK_SEARCH])) {
+                $default = 'ROLE_USER';
+            }
+
+            $this->roles[$type] = $data[$type] ?? $default;
         }
     }
 
     /**
-     * @return array<string, ?string>
+     * @return array<string, string>
      */
     public function getRoles(): array
     {

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -17,6 +17,7 @@ class ContentTypeRoles implements \ArrayAccess
     public const VIEW = 'view';
     public const CREATE = 'create';
     public const EDIT = 'edit';
+    public const PUBLISH = 'publish';
     public const DELETE = 'delete';
     public const TRASH = 'trash';
     public const ARCHIVE = 'archive';
@@ -28,6 +29,7 @@ class ContentTypeRoles implements \ArrayAccess
         self::VIEW,
         self::CREATE,
         self::EDIT,
+        self::PUBLISH,
         self::DELETE,
         self::TRASH,
         self::ARCHIVE,
@@ -53,6 +55,8 @@ class ContentTypeRoles implements \ArrayAccess
             case self::CREATE:
             case self::EDIT:
                 return Roles::ROLE_AUTHOR;
+            case self::PUBLISH:
+                return Roles::ROLE_PUBLISHER;
             case self::SHOW_LINK_SEARCH:
             case self::SHOW_LINK_CREATE:
                 return Roles::ROLE_USER;

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -16,6 +16,7 @@ class ContentTypeRoles implements \ArrayAccess
 
     public const VIEW = 'view';
     public const CREATE = 'create';
+    public const EDIT = 'edit';
     public const DELETE = 'delete';
     public const TRASH = 'trash';
     public const ARCHIVE = 'archive';
@@ -26,6 +27,7 @@ class ContentTypeRoles implements \ArrayAccess
     private const TYPES = [
         self::VIEW,
         self::CREATE,
+        self::EDIT,
         self::DELETE,
         self::TRASH,
         self::ARCHIVE,
@@ -49,6 +51,7 @@ class ContentTypeRoles implements \ArrayAccess
         switch ($type) {
             case self::VIEW:
             case self::CREATE:
+            case self::EDIT:
                 return Roles::ROLE_AUTHOR;
             case self::SHOW_LINK_SEARCH:
             case self::SHOW_LINK_CREATE:

--- a/src/Core/ContentType/ContentTypeRoles.php
+++ b/src/Core/ContentType/ContentTypeRoles.php
@@ -19,6 +19,7 @@ class ContentTypeRoles implements \ArrayAccess
     public const DELETE = 'delete';
     public const TRASH = 'trash';
     public const ARCHIVE = 'archive';
+    public const OWNER = 'owner';
     public const SHOW_LINK_CREATE = 'show_link_create';
     public const SHOW_LINK_SEARCH = 'show_link_search';
 
@@ -28,6 +29,7 @@ class ContentTypeRoles implements \ArrayAccess
         self::DELETE,
         self::TRASH,
         self::ARCHIVE,
+        self::OWNER,
         self::SHOW_LINK_CREATE,
         self::SHOW_LINK_SEARCH,
     ];

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -10,6 +10,7 @@ use EMS\CoreBundle\Core\ContentType\Version\VersionOptions;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
 use EMS\CoreBundle\Entity\Helper\JsonDeserializer;
 use EMS\CoreBundle\Form\DataField\ContainerFieldType;
+use EMS\CoreBundle\Roles;
 use EMS\Helpers\Standard\DateTime;
 
 /**
@@ -1702,6 +1703,11 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
         }
 
         return [];
+    }
+
+    public function role(string $role): string
+    {
+        return $this->getRoles()[$role] ?? Roles::NOT_DEFINED;
     }
 
     public function getRoles(): ContentTypeRoles

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -261,13 +261,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     /**
      * @var string
      *
-     * @ORM\Column(name="edit_role", type="string", length=100, nullable=true)
-     */
-    protected $editRole;
-
-    /**
-     * @var string
-     *
      * @ORM\Column(name="publish_role", type="string", length=100, nullable=true)
      */
     protected $publishRole;
@@ -1333,30 +1326,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getEmailField()
     {
         return $this->emailField;
-    }
-
-    /**
-     * Set editRole.
-     *
-     * @param string $editRole
-     *
-     * @return ContentType
-     */
-    public function setEditRole($editRole)
-    {
-        $this->editRole = $editRole;
-
-        return $this;
-    }
-
-    /**
-     * Get editRole.
-     *
-     * @return string
-     */
-    public function getEditRole()
-    {
-        return $this->editRole;
     }
 
     /**

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -381,20 +381,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected ?string $localeField = null;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="searchLinkDisplayRole", type="string", options={"default" : "ROLE_USER"})
-     */
-    protected $searchLinkDisplayRole = 'ROLE_USER';
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="createLinkDisplayRole", type="string", options={"default" : "ROLE_USER"})
-     */
-    protected $createLinkDisplayRole = 'ROLE_USER';
-
-    /**
      * @var ?string[]
      *
      * @ORM\Column(name="version_tags", type="json", nullable=true)
@@ -423,11 +409,11 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected $versionDateToField;
 
     /**
-     * @var ?array<string, ?string>
+     * @var array<string, string>
      *
      * @ORM\Column(name="roles", type="json", nullable=true)
      */
-    protected ?array $roles = [];
+    protected array $roles = [];
 
     public function __construct()
     {
@@ -1764,30 +1750,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getLocaleField(): ?string
     {
         return $this->localeField;
-    }
-
-    public function setSearchLinkDisplayRole(string $searchLinkDisplayRole): ContentType
-    {
-        $this->searchLinkDisplayRole = $searchLinkDisplayRole;
-
-        return $this;
-    }
-
-    public function getSearchLinkDisplayRole(): string
-    {
-        return $this->searchLinkDisplayRole;
-    }
-
-    public function setCreateLinkDisplayRole(string $createLinkDisplayRole): ContentType
-    {
-        $this->createLinkDisplayRole = $createLinkDisplayRole;
-
-        return $this;
-    }
-
-    public function getCreateLinkDisplayRole(): string
-    {
-        return $this->createLinkDisplayRole;
     }
 
     public function hasVersionTags(): bool

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -260,13 +260,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     /**
      * @var string
      *
-     * @ORM\Column(name="create_role", type="string", length=100, nullable=true)
-     */
-    protected $createRole;
-
-    /**
-     * @var string
-     *
      * @ORM\Column(name="edit_role", type="string", length=100, nullable=true)
      */
     protected $editRole;
@@ -1344,30 +1337,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getEmailField()
     {
         return $this->emailField;
-    }
-
-    /**
-     * Set createRole.
-     *
-     * @param string $createRole
-     *
-     * @return ContentType
-     */
-    public function setCreateRole($createRole)
-    {
-        $this->createRole = $createRole;
-
-        return $this;
-    }
-
-    /**
-     * Get createRole.
-     *
-     * @return string
-     */
-    public function getCreateRole()
-    {
-        return $this->createRole;
     }
 
     /**

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -279,11 +279,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected $publishRole;
 
     /**
-     * @ORM\Column(name="archive_role", type="string", length=100, nullable=true)
-     */
-    protected ?string $archiveRole = null;
-
-    /**
      * @var string
      *
      * @ORM\Column(name="trash_role", type="string", length=100, nullable=true)
@@ -1529,23 +1524,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getPublishRole()
     {
         return $this->publishRole;
-    }
-
-    public function hasArchiveRole(): bool
-    {
-        return null !== $this->archiveRole;
-    }
-
-    public function getArchiveRole(): ?string
-    {
-        return $this->archiveRole;
-    }
-
-    public function setArchiveRole(?string $archiveRole): ContentType
-    {
-        $this->archiveRole = $archiveRole;
-
-        return $this;
     }
 
     /**

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -259,13 +259,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected ?string $sortOrder = null;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="publish_role", type="string", length=100, nullable=true)
-     */
-    protected $publishRole;
-
-    /**
      * @ORM\Column(name="orderKey", type="integer")
      */
     protected int $orderKey = 0;
@@ -1427,30 +1420,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getRefererFieldName()
     {
         return $this->refererFieldName;
-    }
-
-    /**
-     * Set publishRole.
-     *
-     * @param string $publishRole
-     *
-     * @return ContentType
-     */
-    public function setPublishRole($publishRole)
-    {
-        $this->publishRole = $publishRole;
-
-        return $this;
-    }
-
-    /**
-     * Get publishRole.
-     *
-     * @return string
-     */
-    public function getPublishRole()
-    {
-        return $this->publishRole;
     }
 
     /**

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -272,11 +272,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected $publishRole;
 
     /**
-     * @ORM\Column(name="owner_role", type="string", length=100, nullable=true)
-     */
-    protected ?string $ownerRole = null;
-
-    /**
      * @ORM\Column(name="orderKey", type="integer")
      */
     protected int $orderKey = 0;
@@ -1707,32 +1702,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
         }
 
         return [];
-    }
-
-    public function hasOwnerRole(): bool
-    {
-        return null !== $this->ownerRole;
-    }
-
-    public function giveOwnerRole(): string
-    {
-        $ownerRole = $this->ownerRole;
-
-        if (null === $ownerRole) {
-            throw new \RuntimeException('No owner role specified');
-        }
-
-        return $ownerRole;
-    }
-
-    public function getOwnerRole(): ?string
-    {
-        return $this->ownerRole;
-    }
-
-    public function setOwnerRole(?string $ownerRole): void
-    {
-        $this->ownerRole = $ownerRole;
     }
 
     public function getRoles(): ContentTypeRoles

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -5,6 +5,7 @@ namespace EMS\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\ContentType\Version\VersionOptions;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
 use EMS\CoreBundle\Entity\Helper\JsonDeserializer;
@@ -284,11 +285,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected $publishRole;
 
     /**
-     * @ORM\Column(name="delete_role", type="string", length=100, nullable=true)
-     */
-    protected ?string $deleteRole = null;
-
-    /**
      * @ORM\Column(name="archive_role", type="string", length=100, nullable=true)
      */
     protected ?string $archiveRole = null;
@@ -425,6 +421,13 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
      * @ORM\Column(name="version_date_to_field", type="string", length=100, nullable=true)
      */
     protected $versionDateToField;
+
+    /**
+     * @var ?array<string, ?string>
+     *
+     * @ORM\Column(name="roles", type="json", nullable=true)
+     */
+    protected ?array $roles = [];
 
     public function __construct()
     {
@@ -1567,23 +1570,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
         return $this->publishRole;
     }
 
-    public function hasDeleteRole(): bool
-    {
-        return null !== $this->deleteRole;
-    }
-
-    public function getDeleteRole(): ?string
-    {
-        return $this->deleteRole;
-    }
-
-    public function setDeleteRole(?string $deleteRole): ContentType
-    {
-        $this->deleteRole = $deleteRole;
-
-        return $this;
-    }
-
     public function hasArchiveRole(): bool
     {
         return null !== $this->archiveRole;
@@ -1894,5 +1880,15 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function setOwnerRole(?string $ownerRole): void
     {
         $this->ownerRole = $ownerRole;
+    }
+
+    public function getRoles(): ContentTypeRoles
+    {
+        return new ContentTypeRoles($this->roles ?? []);
+    }
+
+    public function setRoles(ContentTypeRoles $roles): void
+    {
+        $this->roles = $roles->getRoles();
     }
 }

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -272,12 +272,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected $editRole;
 
     /**
-     * @ORM\Column(name="view_role", type="string", length=100, nullable=true)
-     * @ORM\OrderBy({"orderKey" = "ASC"})
-     */
-    protected ?string $viewRole;
-
-    /**
      * @var string
      *
      * @ORM\Column(name="publish_role", type="string", length=100, nullable=true)
@@ -1511,25 +1505,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getRefererFieldName()
     {
         return $this->refererFieldName;
-    }
-
-    /**
-     * Set viewRole.
-     *
-     * @param string $viewRole
-     *
-     * @return ContentType
-     */
-    public function setViewRole($viewRole)
-    {
-        $this->viewRole = $viewRole;
-
-        return $this;
-    }
-
-    public function getViewRole(): ?string
-    {
-        return $this->viewRole;
     }
 
     /**

--- a/src/Entity/ContentType.php
+++ b/src/Entity/ContentType.php
@@ -279,13 +279,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     protected $publishRole;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="trash_role", type="string", length=100, nullable=true)
-     */
-    protected $trashRole;
-
-    /**
      * @ORM\Column(name="owner_role", type="string", length=100, nullable=true)
      */
     protected ?string $ownerRole = null;
@@ -1524,30 +1517,6 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getPublishRole()
     {
         return $this->publishRole;
-    }
-
-    /**
-     * Set trashRole.
-     *
-     * @param string $trashRole
-     *
-     * @return ContentType
-     */
-    public function setTrashRole($trashRole)
-    {
-        $this->trashRole = $trashRole;
-
-        return $this;
-    }
-
-    /**
-     * Get trashRole.
-     *
-     * @return string
-     */
-    public function getTrashRole()
-    {
-        return $this->trashRole;
     }
 
     /**

--- a/src/Entity/RevisionTaskTrait.php
+++ b/src/Entity/RevisionTaskTrait.php
@@ -193,7 +193,7 @@ trait RevisionTaskTrait
 
     public function isTaskEnabled(): bool
     {
-        return Roles::NOT_DEFINED !== $this->giveContentType()->getRoles()[ContentTypeRoles::OWNER];
+        return Roles::NOT_DEFINED !== $this->giveContentType()->role(ContentTypeRoles::OWNER);
     }
 
     public function setOwner(string $owner): void

--- a/src/Entity/RevisionTaskTrait.php
+++ b/src/Entity/RevisionTaskTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
+use EMS\CoreBundle\Roles;
 
 trait RevisionTaskTrait
 {
@@ -191,7 +193,7 @@ trait RevisionTaskTrait
 
     public function isTaskEnabled(): bool
     {
-        return $this->giveContentType()->hasOwnerRole();
+        return Roles::NOT_DEFINED !== $this->giveContentType()->getRoles()[ContentTypeRoles::OWNER];
     }
 
     public function setOwner(string $owner): void

--- a/src/Form/Field/RolePickerType.php
+++ b/src/Form/Field/RolePickerType.php
@@ -3,6 +3,7 @@
 namespace EMS\CoreBundle\Form\Field;
 
 use EMS\CoreBundle\EMSCoreBundle;
+use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Service\UserService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -18,7 +19,7 @@ class RolePickerType extends SelectPickerType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $choices = \array_merge(['role.not-defined' => 'not-defined'], $this->userService->listUserRoles());
+        $choices = \array_merge(['role.not-defined' => Roles::NOT_DEFINED], $this->userService->listUserRoles());
 
         $resolver->setDefaults([
             'choices' => $choices,

--- a/src/Form/Field/RolePickerType.php
+++ b/src/Form/Field/RolePickerType.php
@@ -26,7 +26,7 @@ class RolePickerType extends SelectPickerType
             'attr' => ['data-live-search' => true],
             'choice_attr' => function () {
                 return [
-                    'data-icon' => 'fa fa-square',
+                    'data-icon' => 'fa fa-user-circle',
                 ];
             },
             'choice_value' => function ($value) {

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -21,8 +21,11 @@ class ContentTypeRolesType extends AbstractType
         if ($options['managed']) {
             $builder
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
+                ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
             ;
         }
+
+        $builder->add(ContentTypeRoles::SHOW_LINK_SEARCH, RolePickerType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -22,10 +22,11 @@ class ContentTypeRolesType extends AbstractType
 
         if ($options['managed']) {
             $builder
+                ->add(ContentTypeRoles::CREATE, RolePickerType::class)
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
                 ->add(ContentTypeRoles::TRASH, RolePickerType::class)
-                ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
                 ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)
+                ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
             ;
         }
 

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -18,6 +18,8 @@ class ContentTypeRolesType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $builder->add(ContentTypeRoles::VIEW, RolePickerType::class);
+
         if ($options['managed']) {
             $builder
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -24,6 +24,7 @@ class ContentTypeRolesType extends AbstractType
             $builder
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
                 ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
+                ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)
             ;
         }
 

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Form\Form;
+
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
+use EMS\CoreBundle\Form\Field\RolePickerType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentTypeRolesType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface<FormBuilderInterface> $builder
+     * @param array<string, mixed>                       $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($options['managed']) {
+            $builder
+                ->add(ContentTypeRoles::DELETE, RolePickerType::class)
+            ;
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setRequired(['managed']);
+    }
+}

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -26,6 +26,7 @@ class ContentTypeRolesType extends AbstractType
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
                 ->add(ContentTypeRoles::TRASH, RolePickerType::class)
                 ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)
+                ->add(ContentTypeRoles::OWNER, RolePickerType::class)
                 ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
             ;
         }

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -23,6 +23,7 @@ class ContentTypeRolesType extends AbstractType
         if ($options['managed']) {
             $builder
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
+                ->add(ContentTypeRoles::TRASH, RolePickerType::class)
                 ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
                 ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)
             ;

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -23,6 +23,7 @@ class ContentTypeRolesType extends AbstractType
         if ($options['managed']) {
             $builder
                 ->add(ContentTypeRoles::CREATE, RolePickerType::class)
+                ->add(ContentTypeRoles::EDIT, RolePickerType::class)
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
                 ->add(ContentTypeRoles::TRASH, RolePickerType::class)
                 ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)

--- a/src/Form/Form/ContentTypeRolesType.php
+++ b/src/Form/Form/ContentTypeRolesType.php
@@ -24,6 +24,7 @@ class ContentTypeRolesType extends AbstractType
             $builder
                 ->add(ContentTypeRoles::CREATE, RolePickerType::class)
                 ->add(ContentTypeRoles::EDIT, RolePickerType::class)
+                ->add(ContentTypeRoles::PUBLISH, RolePickerType::class)
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
                 ->add(ContentTypeRoles::TRASH, RolePickerType::class)
                 ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -256,8 +256,6 @@ class ContentTypeType extends AbstractType
                 'label' => 'Ask for OUUID',
                 'required' => false,
             ]);
-            $builder->add('publishRole', RolePickerType::class);
-
             $builder->add('orderField');
             $builder->add('saveAndEditStructure', SubmitEmsType::class, [
                     'attr' => [

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -245,10 +245,6 @@ class ContentTypeType extends AbstractType
         $builder->add('rootContentType');
         $builder->add('viewRole', RolePickerType::class);
 
-        $builder->add('searchLinkDisplayRole', RolePickerType::class, [
-            'label' => 'Display the search link in main navigation',
-        ]);
-
         $builder->add('roles', ContentTypeRolesType::class, [
             'managed' => $environment->getManaged(),
             'label' => false,
@@ -267,10 +263,6 @@ class ContentTypeType extends AbstractType
             $builder->add('archiveRole', RolePickerType::class);
             $builder->add('trashRole', RolePickerType::class);
             $builder->add('ownerRole', RolePickerType::class);
-
-            $builder->add('createLinkDisplayRole', RolePickerType::class, [
-                'label' => 'Display the creation link in main navigation',
-            ]);
 
             $builder->add('orderField');
             $builder->add('saveAndEditStructure', SubmitEmsType::class, [

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -249,6 +249,11 @@ class ContentTypeType extends AbstractType
             'label' => 'Display the search link in main navigation',
         ]);
 
+        $builder->add('roles', ContentTypeRolesType::class, [
+            'managed' => $environment->getManaged(),
+            'label' => false,
+        ]);
+
         if ($environment->getManaged()) {
             $builder->add('defaultValue', CodeEditorType::class, [
                 'required' => false,
@@ -260,7 +265,6 @@ class ContentTypeType extends AbstractType
             $builder->add('editRole', RolePickerType::class);
             $builder->add('publishRole', RolePickerType::class);
             $builder->add('archiveRole', RolePickerType::class);
-            $builder->add('deleteRole', RolePickerType::class);
             $builder->add('trashRole', RolePickerType::class);
             $builder->add('ownerRole', RolePickerType::class);
 

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -7,7 +7,6 @@ use EMS\CoreBundle\Form\Field\CodeEditorType;
 use EMS\CoreBundle\Form\Field\ColorPickerType;
 use EMS\CoreBundle\Form\Field\ContentTypeFieldPickerType;
 use EMS\CoreBundle\Form\Field\IconPickerType;
-use EMS\CoreBundle\Form\Field\RolePickerType;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -256,7 +256,6 @@ class ContentTypeType extends AbstractType
                 'label' => 'Ask for OUUID',
                 'required' => false,
             ]);
-            $builder->add('editRole', RolePickerType::class);
             $builder->add('publishRole', RolePickerType::class);
 
             $builder->add('orderField');

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -258,7 +258,6 @@ class ContentTypeType extends AbstractType
             ]);
             $builder->add('editRole', RolePickerType::class);
             $builder->add('publishRole', RolePickerType::class);
-            $builder->add('ownerRole', RolePickerType::class);
 
             $builder->add('orderField');
             $builder->add('saveAndEditStructure', SubmitEmsType::class, [

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -256,7 +256,6 @@ class ContentTypeType extends AbstractType
                 'label' => 'Ask for OUUID',
                 'required' => false,
             ]);
-            $builder->add('createRole', RolePickerType::class);
             $builder->add('editRole', RolePickerType::class);
             $builder->add('publishRole', RolePickerType::class);
             $builder->add('ownerRole', RolePickerType::class);

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -259,7 +259,6 @@ class ContentTypeType extends AbstractType
             $builder->add('createRole', RolePickerType::class);
             $builder->add('editRole', RolePickerType::class);
             $builder->add('publishRole', RolePickerType::class);
-            $builder->add('archiveRole', RolePickerType::class);
             $builder->add('trashRole', RolePickerType::class);
             $builder->add('ownerRole', RolePickerType::class);
 

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -243,7 +243,6 @@ class ContentTypeType extends AbstractType
         ]);
 
         $builder->add('rootContentType');
-        $builder->add('viewRole', RolePickerType::class);
 
         $builder->add('roles', ContentTypeRolesType::class, [
             'managed' => $environment->getManaged(),

--- a/src/Form/Form/ContentTypeType.php
+++ b/src/Form/Form/ContentTypeType.php
@@ -259,7 +259,6 @@ class ContentTypeType extends AbstractType
             $builder->add('createRole', RolePickerType::class);
             $builder->add('editRole', RolePickerType::class);
             $builder->add('publishRole', RolePickerType::class);
-            $builder->add('trashRole', RolePickerType::class);
             $builder->add('ownerRole', RolePickerType::class);
 
             $builder->add('orderField');

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -15,7 +15,8 @@ trait ScriptContentTypeRoles
                 'roles' => Json::encode([
                     'archive' => $row['archive_role'] ?? 'not-defined',
                     'view' => $row['view_role'] ?? 'not-defined',
-                    'delete' => $row['delete_role'] ?? null,
+                    'delete' => $row['delete_role'] ?? 'not-defined',
+                    'trash' => $row['trash_role'] ?? 'not-defined',
                     'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
                     'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
                 ]),
@@ -26,6 +27,7 @@ trait ScriptContentTypeRoles
         $migration->addSql('ALTER TABLE content_type DROP archive_role');
         $migration->addSql('ALTER TABLE content_type DROP view_role');
         $migration->addSql('ALTER TABLE content_type DROP delete_role');
+        $migration->addSql('ALTER TABLE content_type DROP trash_role');
         $migration->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
         $migration->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
     }
@@ -35,6 +37,7 @@ trait ScriptContentTypeRoles
         $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD trash_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
 
@@ -42,6 +45,7 @@ trait ScriptContentTypeRoles
             UPDATE content_type SET 
                 view_role = :view_role,
                 delete_role = :delete_role,
+                trash_role = :trash_role,
                 createLinkDisplayRole = :show_link_create,
                 searchLinkDisplayRole = :show_link_search
             WHERE id = :id
@@ -55,6 +59,7 @@ QUERY;
                 'archive_role' => $roles['archive'] ?? 'not-defined',
                 'view_role' => $roles['view'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
+                'trash_role' => $roles['trash'] ?? 'not-defined',
                 'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
                 'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
                 'id' => $row['id'],

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -15,6 +15,7 @@ trait ScriptContentTypeRoles
                 'roles' => Json::encode([
                     'view' => $row['view_role'] ?? 'not-defined',
                     'create' => $row['create_role'] ?? 'not-defined',
+                    'edit' => $row['edit_role'] ?? 'not-defined',
                     'delete' => $row['delete_role'] ?? 'not-defined',
                     'trash' => $row['trash_role'] ?? 'not-defined',
                     'archive' => $row['archive_role'] ?? 'not-defined',
@@ -28,6 +29,7 @@ trait ScriptContentTypeRoles
 
         $migration->addSql('ALTER TABLE content_type DROP view_role');
         $migration->addSql('ALTER TABLE content_type DROP create_role');
+        $migration->addSql('ALTER TABLE content_type DROP edit_role');
         $migration->addSql('ALTER TABLE content_type DROP delete_role');
         $migration->addSql('ALTER TABLE content_type DROP trash_role');
         $migration->addSql('ALTER TABLE content_type DROP archive_role');
@@ -40,6 +42,7 @@ trait ScriptContentTypeRoles
     {
         $migration->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD create_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD edit_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD trash_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
@@ -51,6 +54,7 @@ trait ScriptContentTypeRoles
             UPDATE content_type SET 
                 view_role = :view_role,
                 create_role = :create_role,
+                edit_role = :edit_role,
                 delete_role = :delete_role,
                 trash_role = :trash_role,
                 archive_role = :archive_role,
@@ -67,6 +71,7 @@ QUERY;
             $migration->addSql($updateQuery, [
                 'view_role' => $roles['view'] ?? 'not-defined',
                 'create_role' => $roles['create'] ?? 'not-defined',
+                'edit_role' => $roles['edit'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'trash_role' => $roles['trash'] ?? 'not-defined',
                 'archive_role' => $roles['archive'] ?? 'not-defined',

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace EMS\CoreBundle\Resources\DoctrineMigrations\Scripts;
+
+use Doctrine\Migrations\AbstractMigration;
+use EMS\Helpers\Standard\Json;
+
+trait ScriptContentTypeRoles
+{
+    public function scriptEncodeRoles(AbstractMigration $migration): void
+    {
+        $result = $migration->connection->executeQuery('select * from content_type');
+        while ($row = $result->fetchAssociative()) {
+            $migration->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
+                'roles' => Json::encode([
+                    'archive' => $row['archive_role'] ?? 'not-defined',
+                    'view' => $row['view_role'] ?? 'not-defined',
+                    'delete' => $row['delete_role'] ?? null,
+                    'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
+                    'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
+                ]),
+                'id' => $row['id'],
+            ]);
+        }
+
+        $migration->addSql('ALTER TABLE content_type DROP archive_role');
+        $migration->addSql('ALTER TABLE content_type DROP view_role');
+        $migration->addSql('ALTER TABLE content_type DROP delete_role');
+        $migration->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
+        $migration->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
+    }
+
+    public function scriptDecodeRoles(AbstractMigration $migration): void
+    {
+        $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
+
+        $updateQuery = <<<QUERY
+            UPDATE content_type SET 
+                view_role = :view_role,
+                delete_role = :delete_role,
+                createLinkDisplayRole = :show_link_create,
+                searchLinkDisplayRole = :show_link_search
+            WHERE id = :id
+QUERY;
+
+        $result = $migration->connection->executeQuery('select * from content_type');
+        while ($row = $result->fetchAssociative()) {
+            $roles = Json::decode($row['roles']);
+
+            $migration->addSql($updateQuery, [
+                'archive_role' => $roles['archive'] ?? 'not-defined',
+                'view_role' => $roles['view'] ?? 'not-defined',
+                'delete_role' => $roles['delete'] ?? 'not-defined',
+                'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
+                'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
+                'id' => $row['id'],
+            ]);
+        }
+
+        $migration->addSql('ALTER TABLE content_type DROP roles');
+    }
+}

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -13,10 +13,10 @@ trait ScriptContentTypeRoles
         while ($row = $result->fetchAssociative()) {
             $migration->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
-                    'view' => $row['view_role'] ?? 'not-defined',
-                    'create' => $row['create_role'] ?? 'not-defined',
-                    'edit' => $row['edit_role'] ?? 'not-defined',
-                    'publish' => $row['publish_role'] ?? 'not-defined',
+                    'view' => $row['view_role'] ?? 'ROLE_AUTHOR',
+                    'create' => $row['create_role'] ?? 'ROLE_AUTHOR',
+                    'edit' => $row['edit_role'] ?? 'ROLE_AUTHOR',
+                    'publish' => $row['publish_role'] ?? 'ROLE_PUBLISHER',
                     'delete' => $row['delete_role'] ?? 'not-defined',
                     'trash' => $row['trash_role'] ?? 'not-defined',
                     'archive' => $row['archive_role'] ?? 'not-defined',
@@ -73,10 +73,10 @@ QUERY;
             $roles = Json::decode($row['roles']);
 
             $migration->addSql($updateQuery, [
-                'view_role' => $roles['view'] ?? 'not-defined',
-                'create_role' => $roles['create'] ?? 'not-defined',
-                'edit_role' => $roles['edit'] ?? 'not-defined',
-                'publish_role' => $roles['publish'] ?? 'not-defined',
+                'view_role' => $roles['view'] ?? 'ROLE_AUTHOR',
+                'create_role' => $roles['create'] ?? 'ROLE_AUTHOR',
+                'edit_role' => $roles['edit'] ?? 'ROLE_AUTHOR',
+                'publish_role' => $roles['publish'] ?? 'ROLE_PUBLISHER',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'trash_role' => $roles['trash'] ?? 'not-defined',
                 'archive_role' => $roles['archive'] ?? 'not-defined',

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -13,10 +13,11 @@ trait ScriptContentTypeRoles
         while ($row = $result->fetchAssociative()) {
             $migration->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
-                    'archive' => $row['archive_role'] ?? 'not-defined',
                     'view' => $row['view_role'] ?? 'not-defined',
+                    'create' => $row['create_role'] ?? 'not-defined',
                     'delete' => $row['delete_role'] ?? 'not-defined',
                     'trash' => $row['trash_role'] ?? 'not-defined',
+                    'archive' => $row['archive_role'] ?? 'not-defined',
                     'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
                     'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
                 ]),
@@ -26,6 +27,7 @@ trait ScriptContentTypeRoles
 
         $migration->addSql('ALTER TABLE content_type DROP archive_role');
         $migration->addSql('ALTER TABLE content_type DROP view_role');
+        $migration->addSql('ALTER TABLE content_type DROP create_role');
         $migration->addSql('ALTER TABLE content_type DROP delete_role');
         $migration->addSql('ALTER TABLE content_type DROP trash_role');
         $migration->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
@@ -36,6 +38,7 @@ trait ScriptContentTypeRoles
     {
         $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD create_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD trash_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
@@ -44,8 +47,10 @@ trait ScriptContentTypeRoles
         $updateQuery = <<<QUERY
             UPDATE content_type SET 
                 view_role = :view_role,
+                create_role = :create_role,
                 delete_role = :delete_role,
                 trash_role = :trash_role,
+                archive_role = :archive_role,
                 createLinkDisplayRole = :show_link_create,
                 searchLinkDisplayRole = :show_link_search
             WHERE id = :id
@@ -56,10 +61,11 @@ QUERY;
             $roles = Json::decode($row['roles']);
 
             $migration->addSql($updateQuery, [
-                'archive_role' => $roles['archive'] ?? 'not-defined',
                 'view_role' => $roles['view'] ?? 'not-defined',
+                'create_role' => $roles['create'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'trash_role' => $roles['trash'] ?? 'not-defined',
+                'archive_role' => $roles['archive'] ?? 'not-defined',
                 'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
                 'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
                 'id' => $row['id'],

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -18,6 +18,7 @@ trait ScriptContentTypeRoles
                     'delete' => $row['delete_role'] ?? 'not-defined',
                     'trash' => $row['trash_role'] ?? 'not-defined',
                     'archive' => $row['archive_role'] ?? 'not-defined',
+                    'owner' => $row['owner_role'] ?? 'not-defined',
                     'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
                     'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
                 ]),
@@ -25,22 +26,24 @@ trait ScriptContentTypeRoles
             ]);
         }
 
-        $migration->addSql('ALTER TABLE content_type DROP archive_role');
         $migration->addSql('ALTER TABLE content_type DROP view_role');
         $migration->addSql('ALTER TABLE content_type DROP create_role');
         $migration->addSql('ALTER TABLE content_type DROP delete_role');
         $migration->addSql('ALTER TABLE content_type DROP trash_role');
+        $migration->addSql('ALTER TABLE content_type DROP archive_role');
+        $migration->addSql('ALTER TABLE content_type DROP owner_role');
         $migration->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
         $migration->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
     }
 
     public function scriptDecodeRoles(AbstractMigration $migration): void
     {
-        $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD create_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD trash_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD owner_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
 
@@ -51,6 +54,7 @@ trait ScriptContentTypeRoles
                 delete_role = :delete_role,
                 trash_role = :trash_role,
                 archive_role = :archive_role,
+                owner_role = :owner_role,
                 createLinkDisplayRole = :show_link_create,
                 searchLinkDisplayRole = :show_link_search
             WHERE id = :id
@@ -66,6 +70,7 @@ QUERY;
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'trash_role' => $roles['trash'] ?? 'not-defined',
                 'archive_role' => $roles['archive'] ?? 'not-defined',
+                'owner_role' => $roles['owner'] ?? 'not-defined',
                 'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
                 'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
                 'id' => $row['id'],

--- a/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
+++ b/src/Resources/DoctrineMigrations/Scripts/ScriptContentTypeRoles.php
@@ -16,6 +16,7 @@ trait ScriptContentTypeRoles
                     'view' => $row['view_role'] ?? 'not-defined',
                     'create' => $row['create_role'] ?? 'not-defined',
                     'edit' => $row['edit_role'] ?? 'not-defined',
+                    'publish' => $row['publish_role'] ?? 'not-defined',
                     'delete' => $row['delete_role'] ?? 'not-defined',
                     'trash' => $row['trash_role'] ?? 'not-defined',
                     'archive' => $row['archive_role'] ?? 'not-defined',
@@ -30,6 +31,7 @@ trait ScriptContentTypeRoles
         $migration->addSql('ALTER TABLE content_type DROP view_role');
         $migration->addSql('ALTER TABLE content_type DROP create_role');
         $migration->addSql('ALTER TABLE content_type DROP edit_role');
+        $migration->addSql('ALTER TABLE content_type DROP publish_role');
         $migration->addSql('ALTER TABLE content_type DROP delete_role');
         $migration->addSql('ALTER TABLE content_type DROP trash_role');
         $migration->addSql('ALTER TABLE content_type DROP archive_role');
@@ -43,6 +45,7 @@ trait ScriptContentTypeRoles
         $migration->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD create_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD edit_role VARCHAR(100) DEFAULT NULL');
+        $migration->addSql('ALTER TABLE content_type ADD publish_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD trash_role VARCHAR(100) DEFAULT NULL');
         $migration->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
@@ -55,6 +58,7 @@ trait ScriptContentTypeRoles
                 view_role = :view_role,
                 create_role = :create_role,
                 edit_role = :edit_role,
+                publish_role = :publish_role,
                 delete_role = :delete_role,
                 trash_role = :trash_role,
                 archive_role = :archive_role,
@@ -72,6 +76,7 @@ QUERY;
                 'view_role' => $roles['view'] ?? 'not-defined',
                 'create_role' => $roles['create'] ?? 'not-defined',
                 'edit_role' => $roles['edit'] ?? 'not-defined',
+                'publish_role' => $roles['publish'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'trash_role' => $roles['trash'] ?? 'not-defined',
                 'archive_role' => $roles['archive'] ?? 'not-defined',

--- a/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
+++ b/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
@@ -25,12 +25,16 @@ final class Version20221020135425 extends AbstractMigration
             $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
                     'delete' => $row['delete_role'] ?? null,
+                    'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
+                    'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
                 ]),
                 'id' => $row['id'],
             ]);
         }
 
         $this->addSql('ALTER TABLE content_type DROP delete_role');
+        $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
+        $this->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
     }
 
     public function down(Schema $schema): void
@@ -41,13 +45,25 @@ final class Version20221020135425 extends AbstractMigration
         );
 
         $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
+        $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
+        $this->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
+
+        $updateQuery = <<<QUERY
+            UPDATE content_type SET 
+                delete_role = :delete_role,
+                createLinkDisplayRole = :show_link_create,
+                searchLinkDisplayRole = :show_link_search
+            WHERE id = :id
+QUERY;
 
         $result = $this->connection->executeQuery('select * from content_type');
         while ($row = $result->fetchAssociative()) {
             $roles = Json::decode($row['roles']);
 
-            $this->addSql('UPDATE content_type SET delete_role = :delete_role WHERE id = :id', [
-                'delete_role' => $roles['delete'] ?? null,
+            $this->addSql($updateQuery, [
+                'delete_role' => $roles['delete'] ?? 'not-defined',
+                'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
+                'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
                 'id' => $row['id'],
             ]);
         }

--- a/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
+++ b/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
@@ -24,6 +24,7 @@ final class Version20221020135425 extends AbstractMigration
         while ($row = $result->fetchAssociative()) {
             $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
+                    'archive' => $row['archive_role'] ?? 'not-defined',
                     'view' => $row['view_role'] ?? 'not-defined',
                     'delete' => $row['delete_role'] ?? null,
                     'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
@@ -33,6 +34,7 @@ final class Version20221020135425 extends AbstractMigration
             ]);
         }
 
+        $this->addSql('ALTER TABLE content_type DROP archive_role');
         $this->addSql('ALTER TABLE content_type DROP view_role');
         $this->addSql('ALTER TABLE content_type DROP delete_role');
         $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
@@ -46,6 +48,7 @@ final class Version20221020135425 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
         );
 
+        $this->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
@@ -65,6 +68,7 @@ QUERY;
             $roles = Json::decode($row['roles']);
 
             $this->addSql($updateQuery, [
+                'archive_role' => $roles['archive'] ?? 'not-defined',
                 'view_role' => $roles['view'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',

--- a/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
+++ b/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
@@ -7,10 +7,12 @@ namespace Application\Migrations;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
-use EMS\Helpers\Standard\Json;
+use EMS\CoreBundle\Resources\DoctrineMigrations\Scripts\ScriptContentTypeRoles;
 
 final class Version20221020135425 extends AbstractMigration
 {
+    use ScriptContentTypeRoles;
+
     public function up(Schema $schema): void
     {
         $this->abortIf(
@@ -20,25 +22,7 @@ final class Version20221020135425 extends AbstractMigration
 
         $this->addSql('ALTER TABLE content_type ADD roles LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
 
-        $result = $this->connection->executeQuery('select * from content_type');
-        while ($row = $result->fetchAssociative()) {
-            $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
-                'roles' => Json::encode([
-                    'archive' => $row['archive_role'] ?? 'not-defined',
-                    'view' => $row['view_role'] ?? 'not-defined',
-                    'delete' => $row['delete_role'] ?? null,
-                    'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
-                    'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
-                ]),
-                'id' => $row['id'],
-            ]);
-        }
-
-        $this->addSql('ALTER TABLE content_type DROP archive_role');
-        $this->addSql('ALTER TABLE content_type DROP view_role');
-        $this->addSql('ALTER TABLE content_type DROP delete_role');
-        $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
-        $this->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
+        $this->scriptEncodeRoles($this);
     }
 
     public function down(Schema $schema): void
@@ -48,35 +32,6 @@ final class Version20221020135425 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
         );
 
-        $this->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
-
-        $updateQuery = <<<QUERY
-            UPDATE content_type SET 
-                view_role = :view_role,
-                delete_role = :delete_role,
-                createLinkDisplayRole = :show_link_create,
-                searchLinkDisplayRole = :show_link_search
-            WHERE id = :id
-QUERY;
-
-        $result = $this->connection->executeQuery('select * from content_type');
-        while ($row = $result->fetchAssociative()) {
-            $roles = Json::decode($row['roles']);
-
-            $this->addSql($updateQuery, [
-                'archive_role' => $roles['archive'] ?? 'not-defined',
-                'view_role' => $roles['view'] ?? 'not-defined',
-                'delete_role' => $roles['delete'] ?? 'not-defined',
-                'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
-                'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
-                'id' => $row['id'],
-            ]);
-        }
-
-        $this->addSql('ALTER TABLE content_type DROP roles');
+        $this->scriptDecodeRoles($this);
     }
 }

--- a/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
+++ b/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use EMS\Helpers\Standard\Json;
+
+final class Version20221020135425 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type ADD roles LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
+
+        $result = $this->connection->executeQuery('select * from content_type');
+        while ($row = $result->fetchAssociative()) {
+            $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
+                'roles' => Json::encode([
+                    'delete' => $row['delete_role'] ?? null,
+                ]),
+                'id' => $row['id'],
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE content_type DROP delete_role');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
+
+        $result = $this->connection->executeQuery('select * from content_type');
+        while ($row = $result->fetchAssociative()) {
+            $roles = Json::decode($row['roles']);
+
+            $this->addSql('UPDATE content_type SET delete_role = :delete_role WHERE id = :id', [
+                'delete_role' => $roles['delete'] ?? null,
+                'id' => $row['id'],
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE content_type DROP roles');
+    }
+}

--- a/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
+++ b/src/Resources/DoctrineMigrations/pdo_mysql/Version20221020135425.php
@@ -24,6 +24,7 @@ final class Version20221020135425 extends AbstractMigration
         while ($row = $result->fetchAssociative()) {
             $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
+                    'view' => $row['view_role'] ?? 'not-defined',
                     'delete' => $row['delete_role'] ?? null,
                     'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
                     'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
@@ -32,6 +33,7 @@ final class Version20221020135425 extends AbstractMigration
             ]);
         }
 
+        $this->addSql('ALTER TABLE content_type DROP view_role');
         $this->addSql('ALTER TABLE content_type DROP delete_role');
         $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
         $this->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
@@ -44,12 +46,14 @@ final class Version20221020135425 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
         );
 
+        $this->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
 
         $updateQuery = <<<QUERY
             UPDATE content_type SET 
+                view_role = :view_role,
                 delete_role = :delete_role,
                 createLinkDisplayRole = :show_link_create,
                 searchLinkDisplayRole = :show_link_search
@@ -61,6 +65,7 @@ QUERY;
             $roles = Json::decode($row['roles']);
 
             $this->addSql($updateQuery, [
+                'view_role' => $roles['view'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
                 'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use EMS\Helpers\Standard\Json;
+
+final class Version20221020125332 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE content_type ADD roles JSON DEFAULT NULL');
+
+        $result = $this->connection->executeQuery('select * from content_type');
+        while ($row = $result->fetchAssociative()) {
+            $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
+                'roles' => Json::encode([
+                    'delete' => $row['delete_role'] ?? null,
+                ]),
+                'id' => $row['id'],
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE content_type DROP delete_role');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
+
+        $result = $this->connection->executeQuery('select * from content_type');
+        while ($row = $result->fetchAssociative()) {
+            $roles = Json::decode($row['roles']);
+
+            $this->addSql('UPDATE content_type SET delete_role = :delete_role WHERE id = :id', [
+                'delete_role' => $roles['delete'] ?? null,
+                'id' => $row['id'],
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE content_type DROP roles');
+    }
+}

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
@@ -7,10 +7,12 @@ namespace Application\Migrations;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
-use EMS\Helpers\Standard\Json;
+use EMS\CoreBundle\Resources\DoctrineMigrations\Scripts\ScriptContentTypeRoles;
 
 final class Version20221020125332 extends AbstractMigration
 {
+    use ScriptContentTypeRoles;
+
     public function up(Schema $schema): void
     {
         $this->abortIf(
@@ -20,25 +22,7 @@ final class Version20221020125332 extends AbstractMigration
 
         $this->addSql('ALTER TABLE content_type ADD roles JSON DEFAULT NULL');
 
-        $result = $this->connection->executeQuery('select * from content_type');
-        while ($row = $result->fetchAssociative()) {
-            $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
-                'roles' => Json::encode([
-                    'archive' => $row['archive_role'] ?? 'not-defined',
-                    'view' => $row['view_role'] ?? 'not-defined',
-                    'delete' => $row['delete_role'] ?? 'not-defined',
-                    'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
-                    'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
-                ]),
-                'id' => $row['id'],
-            ]);
-        }
-
-        $this->addSql('ALTER TABLE content_type DROP archive_role');
-        $this->addSql('ALTER TABLE content_type DROP view_role');
-        $this->addSql('ALTER TABLE content_type DROP delete_role');
-        $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
-        $this->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
+        $this->scriptEncodeRoles($this);
     }
 
     public function down(Schema $schema): void
@@ -48,36 +32,6 @@ final class Version20221020125332 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
         );
 
-        $this->addSql('ALTER TABLE content_type ADD archive_role VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
-        $this->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
-
-        $updateQuery = <<<QUERY
-            UPDATE content_type SET 
-                archive_role = :archive_role,
-                view_role = :view_role,
-                delete_role = :delete_role,
-                createLinkDisplayRole = :show_link_create,
-                searchLinkDisplayRole = :show_link_search
-            WHERE id = :id
-QUERY;
-
-        $result = $this->connection->executeQuery('select * from content_type');
-        while ($row = $result->fetchAssociative()) {
-            $roles = Json::decode($row['roles']);
-
-            $this->addSql($updateQuery, [
-                'archive_role' => $roles['archive'] ?? 'not-defined',
-                'view_role' => $roles['view'] ?? 'not-defined',
-                'delete_role' => $roles['delete'] ?? 'not-defined',
-                'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
-                'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
-                'id' => $row['id'],
-            ]);
-        }
-
-        $this->addSql('ALTER TABLE content_type DROP roles');
+        $this->scriptDecodeRoles($this);
     }
 }

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 use EMS\Helpers\Standard\Json;
@@ -12,12 +13,18 @@ final class Version20221020125332 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
         $this->addSql('ALTER TABLE content_type ADD roles JSON DEFAULT NULL');
 
         $result = $this->connection->executeQuery('select * from content_type');
         while ($row = $result->fetchAssociative()) {
             $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
+                    'view' => $row['view_role'] ?? 'not-defined',
                     'delete' => $row['delete_role'] ?? 'not-defined',
                     'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
                     'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
@@ -26,6 +33,7 @@ final class Version20221020125332 extends AbstractMigration
             ]);
         }
 
+        $this->addSql('ALTER TABLE content_type DROP view_role');
         $this->addSql('ALTER TABLE content_type DROP delete_role');
         $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
         $this->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
@@ -33,12 +41,19 @@ final class Version20221020125332 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE content_type ADD view_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
         $this->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
 
         $updateQuery = <<<QUERY
             UPDATE content_type SET 
+                view_role = :view_role,
                 delete_role = :delete_role,
                 createLinkDisplayRole = :show_link_create,
                 searchLinkDisplayRole = :show_link_search
@@ -50,6 +65,7 @@ QUERY;
             $roles = Json::decode($row['roles']);
 
             $this->addSql($updateQuery, [
+                'view_role' => $roles['view'] ?? 'not-defined',
                 'delete_role' => $roles['delete'] ?? 'not-defined',
                 'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
                 'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',

--- a/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
+++ b/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221020125332.php
@@ -18,25 +18,41 @@ final class Version20221020125332 extends AbstractMigration
         while ($row = $result->fetchAssociative()) {
             $this->addSql('UPDATE content_type SET roles = :roles WHERE id = :id', [
                 'roles' => Json::encode([
-                    'delete' => $row['delete_role'] ?? null,
+                    'delete' => $row['delete_role'] ?? 'not-defined',
+                    'show_link_create' => $row['createLinkDisplayRole'] ?? 'ROLE_USER',
+                    'show_link_search' => $row['searchLinkDisplayRole'] ?? 'ROLE_USER',
                 ]),
                 'id' => $row['id'],
             ]);
         }
 
         $this->addSql('ALTER TABLE content_type DROP delete_role');
+        $this->addSql('ALTER TABLE content_type DROP createLinkDisplayRole');
+        $this->addSql('ALTER TABLE content_type DROP searchLinkDisplayRole');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE content_type ADD delete_role VARCHAR(100) DEFAULT NULL');
+        $this->addSql('ALTER TABLE content_type ADD createLinkDisplayRole VARCHAR(100) DEFAULT NULL');
+        $this->addSql('ALTER TABLE content_type ADD searchLinkDisplayRole VARCHAR(100) DEFAULT NULL');
+
+        $updateQuery = <<<QUERY
+            UPDATE content_type SET 
+                delete_role = :delete_role,
+                createLinkDisplayRole = :show_link_create,
+                searchLinkDisplayRole = :show_link_search
+            WHERE id = :id
+QUERY;
 
         $result = $this->connection->executeQuery('select * from content_type');
         while ($row = $result->fetchAssociative()) {
             $roles = Json::decode($row['roles']);
 
-            $this->addSql('UPDATE content_type SET delete_role = :delete_role WHERE id = :id', [
-                'delete_role' => $roles['delete'] ?? null,
+            $this->addSql($updateQuery, [
+                'delete_role' => $roles['delete'] ?? 'not-defined',
+                'show_link_create' => $roles['show_link_create'] ?? 'ROLE_USER',
+                'show_link_search' => $roles['show_link_search'] ?? 'ROLE_USER',
                 'id' => $row['id'],
             ]);
         }

--- a/src/Resources/translations/emsco-forms.en.yml
+++ b/src/Resources/translations/emsco-forms.en.yml
@@ -39,6 +39,7 @@ ROLE_DEFAULT_SEARCH: 'Default search'
 ROLE_FORM_CRM: 'Form CRM'
 ROLE_PUBLISHER: Publisher
 ROLE_REVIEWER: Reviewer
+ROLE_AUDITOR: Auditor
 ROLE_SUPER: 'Super user'
 ROLE_SUPER_ADMIN: 'Super Admin'
 ROLE_SUPER_AUTHOR: 'Super Author'

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -34,13 +34,30 @@
                         {{ form_row(form.editTwigWithWysiwyg) }}
                         {{ form_row(form.singularName) }}
                         {{ form_row(form.pluralName) }}
+
+                        <table class="table table-condense">
+                            <thead>
+                                <tr>
+                                    <th>Permission</th>
+                                    <th>Role</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for elementRole in form.roles %}
+                                    <tr>
+                                        <td>{{ form_label(elementRole) }}</td>
+                                        <td>{{ form_widget(elementRole) }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+
                         {{ form_row(form.viewRole) }}
                         {% if contentType.environment.managed %}
                             {{ form_row(form.createRole) }}
                             {{ form_row(form.editRole) }}
                             {{ form_row(form.publishRole) }}
                             {{ form_row(form.archiveRole) }}
-                            {{ form_row(form.deleteRole) }}
                             {{ form_row(form.trashRole) }}
                             {{ form_row(form.ownerRole) }}
                             {{ form_row(form.createLinkDisplayRole) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -56,7 +56,6 @@
                             {{ form_row(form.createRole) }}
                             {{ form_row(form.editRole) }}
                             {{ form_row(form.publishRole) }}
-                            {{ form_row(form.trashRole) }}
                             {{ form_row(form.ownerRole) }}
                         {% endif %}
                         {{ form_row(form.icon) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -35,7 +35,7 @@
                         {{ form_row(form.singularName) }}
                         {{ form_row(form.pluralName) }}
 
-                        <table class="table table-condense">
+                        <table class="table table-hover">
                             <thead>
                                 <tr>
                                     <th>Permission</th>

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -51,10 +51,6 @@
                                 {% endfor %}
                             </tbody>
                         </table>
-
-                        {% if contentType.environment.managed %}
-                            {{ form_row(form.publishRole) }}
-                        {% endif %}
                         {{ form_row(form.icon) }}
                         {{ form_row(form.color) }}
                         {{ form_row(form.refererFieldName) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -55,7 +55,6 @@
                         {% if contentType.environment.managed %}
                             {{ form_row(form.editRole) }}
                             {{ form_row(form.publishRole) }}
-                            {{ form_row(form.ownerRole) }}
                         {% endif %}
                         {{ form_row(form.icon) }}
                         {{ form_row(form.color) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -56,7 +56,6 @@
                             {{ form_row(form.createRole) }}
                             {{ form_row(form.editRole) }}
                             {{ form_row(form.publishRole) }}
-                            {{ form_row(form.archiveRole) }}
                             {{ form_row(form.trashRole) }}
                             {{ form_row(form.ownerRole) }}
                         {% endif %}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -53,7 +53,6 @@
                         </table>
 
                         {% if contentType.environment.managed %}
-                            {{ form_row(form.createRole) }}
                             {{ form_row(form.editRole) }}
                             {{ form_row(form.publishRole) }}
                             {{ form_row(form.ownerRole) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -52,7 +52,6 @@
                             </tbody>
                         </table>
 
-                        {{ form_row(form.viewRole) }}
                         {% if contentType.environment.managed %}
                             {{ form_row(form.createRole) }}
                             {{ form_row(form.editRole) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -60,9 +60,7 @@
                             {{ form_row(form.archiveRole) }}
                             {{ form_row(form.trashRole) }}
                             {{ form_row(form.ownerRole) }}
-                            {{ form_row(form.createLinkDisplayRole) }}
                         {% endif %}
-                        {{ form_row(form.searchLinkDisplayRole) }}
                         {{ form_row(form.icon) }}
                         {{ form_row(form.color) }}
                         {{ form_row(form.refererFieldName) }}

--- a/src/Resources/views/contenttype/edit.html.twig
+++ b/src/Resources/views/contenttype/edit.html.twig
@@ -53,7 +53,6 @@
                         </table>
 
                         {% if contentType.environment.managed %}
-                            {{ form_row(form.editRole) }}
                             {{ form_row(form.publishRole) }}
                         {% endif %}
                         {{ form_row(form.icon) }}

--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -112,7 +112,7 @@
 {% block revisionSidebar %}
 	{% set tabs = [{name: 'tab_about_revision', label: 'views.data.revisions-data-html.revision'|trans}] %}
 	{% if revision.isTaskEnabled %}
-		{% if (revision.hasOwner and revision.owner == app.user.username) or (revision.hasTasks == false and is_granted(revision.giveContentType.ownerRole) and revision.hasOwner == false) %}
+		{% if (revision.hasOwner and revision.owner == app.user.username) or (revision.hasTasks == false and is_granted(revision.giveContentType.roles.owner) and revision.hasOwner == false) %}
 			{% set tabs = tabs|merge([{ name: 'tab_tasks', label: 'task.tab_tasks'|trans }]) %}
 		{% endif %}
 		{% if revision.hasTaskCurrent and revision.owner != app.user.username %}

--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -92,7 +92,7 @@
 				{% endif %}
 
 				{% set ctRoles = revision.contentType.roles %}
-				{% if ctRoles.delete is defined and is_granted(ctRoles.delete) or (false == revision.contentType.hasDeleteRole and is_granted(revision.contentType.createRole)) %}
+				{% if is_granted(ctRoles.delete) %}
 					{% if not  revision.contentType.circlesField or attribute(object._source, revision.contentType.circlesField) is not defined or attribute(object._source, revision.contentType.circlesField)|in_my_circles %}
 						{% include '@EMSCore/elements/post-button.html.twig' with {
 							'url':  path('object.delete', {'type': revision.contentType.name, 'ouuid': revision.ouuid} ),

--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -90,7 +90,9 @@
 						'message': 'Do you confirm?'
 					}%}
 				{% endif %}
-				{% if is_granted(revision.contentType.deleteRole) or (false == revision.contentType.hasDeleteRole and is_granted(revision.contentType.createRole)) %}
+
+				{% set ctRoles = revision.contentType.roles %}
+				{% if ctRoles.delete is defined and is_granted(ctRoles.delete) or (false == revision.contentType.hasDeleteRole and is_granted(revision.contentType.createRole)) %}
 					{% if not  revision.contentType.circlesField or attribute(object._source, revision.contentType.circlesField) is not defined or attribute(object._source, revision.contentType.circlesField)|in_my_circles %}
 						{% include '@EMSCore/elements/post-button.html.twig' with {
 							'url':  path('object.delete', {'type': revision.contentType.name, 'ouuid': revision.ouuid} ),

--- a/src/Resources/views/data/revisions-data.html.twig
+++ b/src/Resources/views/data/revisions-data.html.twig
@@ -81,7 +81,9 @@
 				'vertical': false,
 			}%}
 			<div class="btn-group pull-right">
-				{% if not revision.archived and revision.contentType.archiveRole and is_granted(revision.contentType.archiveRole) and not revision.hasEndTime %}
+				{% set ctRoles = revision.contentType.roles %}
+
+				{% if not revision.archived and is_granted(ctRoles.archive) and not revision.hasEndTime %}
 					{% include '@EMSCore/elements/post-button.html.twig' with {
 						'url':  path('emsco_revision_archive', {'revision': revision.id} ),
 						'label': 'Archive',
@@ -91,7 +93,6 @@
 					}%}
 				{% endif %}
 
-				{% set ctRoles = revision.contentType.roles %}
 				{% if is_granted(ctRoles.delete) %}
 					{% if not  revision.contentType.circlesField or attribute(object._source, revision.contentType.circlesField) is not defined or attribute(object._source, revision.contentType.circlesField)|in_my_circles %}
 						{% include '@EMSCore/elements/post-button.html.twig' with {

--- a/src/Resources/views/elasticsearch/search.html.twig
+++ b/src/Resources/views/elasticsearch/search.html.twig
@@ -243,7 +243,7 @@
 			</div>
 		</div>
 	</div>
-		{% if body is defined and form.environments.vars.value|length == 1  and form.contentTypes.vars.value|length == 1  and form.contentTypes.vars.value.0|get_content_type.publishRole is defined and is_granted(form.contentTypes.vars.value.0|get_content_type.publishRole) and form.environments.vars.value.0|get_environment.managed and response.total > 1 %}
+		{% if body is defined and form.environments.vars.value|length == 1  and form.contentTypes.vars.value|length == 1  and is_granted(form.contentTypes.vars.value.0|get_content_type.roles.publish) and form.environments.vars.value.0|get_environment.managed and response.total > 1 %}
 			<div class="col-md-12">
 				<div class="box">
 					<div class="box-footer with-border">

--- a/src/Resources/views/elements/object-toolbar.html.twig
+++ b/src/Resources/views/elements/object-toolbar.html.twig
@@ -21,7 +21,7 @@
 					'label': info.draft ? 'views.elements.object-toolbar-html.view-draft-in-progress'|trans : 'views.elements.object-toolbar-html.view-current-revision'|trans,
 					'icon': 'archive'
 				}%}
-				{% if is_granted(contentType.editRole) %}
+				{% if is_granted(contentType.roles.edit) %}
 					{% if not  contentType.circlesField or attribute(source, contentType.circlesField) is not defined or attribute(source, contentType.circlesField)|in_my_circles %}
 						{% include '@EMSCore/elements/post-button.html.twig' with {
 							'url': path('revision.new-draft', {'ouuid': ouuid, 'type': contentType.name}),

--- a/src/Resources/views/elements/revision-toolbar.html.twig
+++ b/src/Resources/views/elements/revision-toolbar.html.twig
@@ -12,7 +12,7 @@
 			'icon': 'eye' }%}
 
 	{% endif %}
-	{% if current and not draft %}
+	{% if current and not draft and is_granted(instance.contentType.roles.edit) %}
 		{% include '@EMSCore/elements/post-button.html.twig' with {
 			'url': path('revision.new-draft', {'ouuid': revision.ouuid, 'type':revision.contentType.name, 'item': app.request.get('item') }),
 			'label': 'views.elements.revision-toolbar-html.new-draft-label'|trans,
@@ -20,7 +20,7 @@
 			'icon': 'pencil' }%}
 	{% endif %}
 	{% if draft %} 	
-		{% if is_granted(instance.contentType.editRole) %}
+		{% if is_granted(instance.contentType.roles.edit) %}
 			{% if not  instance.contentType.circlesField or attribute(instance.rawData, instance.contentType.circlesField) is not defined or attribute(instance.rawData, instance.contentType.circlesField)|in_my_circles %}
 				<div class="btn-group">
 					{% include '@EMSCore/elements/get-button.html.twig' with {
@@ -93,7 +93,7 @@
    		{% endfor %}
 
 
-	   	{% if is_granted(instance.contentType.editRole) %}
+	   	{% if is_granted(instance.contentType.roles.edit) %}
 	   		{% if not  instance.contentType.circlesField or attribute(object._source,instance.contentType.circlesField) is not defined or attribute(object._source,instance.contentType.circlesField)|in_my_circles %}
 
 

--- a/src/Resources/views/elements/revision-toolbar.html.twig
+++ b/src/Resources/views/elements/revision-toolbar.html.twig
@@ -74,7 +74,7 @@
 		{# TODO: better way to determine if there is a environement to publish this revision in ? #}
 		{# twig function ?#}
 		{% set hasEnv = false %}
-		{% if  is_granted(instance.contentType.publishRole) %}
+		{% if is_granted(instance.contentType.roles.publish) %}
 			{% for env in availableEnv %}
 				{% if env not in environments and env.circles|in_my_circles %}
 					{% set hasEnv = true %}
@@ -167,7 +167,7 @@
 			
 			</div>
 			<div class="btn-group{% if vertical is defined and vertical %}-vertical{% endif %}">
-			  {% if instance.contentType.publishRole and is_granted(instance.contentType.publishRole) and hasEnv  %}
+			  {% if is_granted(instance.contentType.roles.publish) and hasEnv  %}
 					<div class="btn-group">
 					  <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 							<span class="fa fa-toggle-on"></span>&nbsp;
@@ -187,7 +187,7 @@
 			  {% endif %}
 
 			  {% set unpublishableEnvironments = availableEnv|filter(env => env in environments and env.circles|in_my_circles) %}
-			  {% if unpublishableEnvironments|length > 0 and instance.contentType.publishRole and is_granted(instance.contentType.publishRole) and ((environments|length > 0 and not current) or (environments|length > 1 and current)) %}
+			  {% if unpublishableEnvironments|length > 0 and is_granted(instance.contentType.roles.publish) and ((environments|length > 0 and not current) or (environments|length > 1 and current)) %}
 				<div class="btn-group">
 					  <button type="button" class="btn btn-sm btn-outline-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 							<span class="fa fa-toggle-off"></span>&nbsp;

--- a/src/Resources/views/environment/align.html.twig
+++ b/src/Resources/views/environment/align.html.twig
@@ -110,7 +110,7 @@
             <tr>
               <td>{{ loop.index+((page-1)*paging_size) }}.</td>
               <td>
-                  {% if  (is_granted('ROLE_ALLOW_ALIGN') and is_granted(item.contentType.publishRole))  %}
+                  {% if  (is_granted('ROLE_ALLOW_ALIGN') and is_granted(item.contentType.roles.publish))  %}
                     <input class="item-to-align" type="checkbox" name="compare_environment_form[item_to_align][{{ minrev[1] }}]" value="{{ item.content_type_name }}:{{ item.ouuid }}">
                   {% endif %}
               </td>
@@ -183,7 +183,7 @@
                 {% endif %}
               </td>
               <td>
-                {% if is_granted('ROLE_ALLOW_ALIGN') and is_granted(item.contentType.publishRole) %}
+                {% if is_granted('ROLE_ALLOW_ALIGN') and is_granted(item.contentType.roles.publish) %}
                     <div class="btn-group">
 
                             {%  if defaultEnv and withEnv.id != defaultEnv.id  and toInMyCircles %}

--- a/src/Roles.php
+++ b/src/Roles.php
@@ -6,6 +6,8 @@ namespace EMS\CoreBundle;
 
 class Roles
 {
+    public const NOT_DEFINED = 'not-defined';
+
     public const ROLE_API = 'ROLE_API';
     public const ROLE_USER = 'ROLE_USER';
     public const ROLE_AUTHOR = 'ROLE_AUTHOR';

--- a/src/Service/ContentTypeService.php
+++ b/src/Service/ContentTypeService.php
@@ -553,7 +553,7 @@ class ContentTypeService implements EntityServiceInterface
                     '%name%' => $contentType->getSingularName(),
                 ]);
             }
-            if ($this->authorizationChecker->isGranted($contentType->getTrashRole())) {
+            if ($this->authorizationChecker->isGranted($roles[ContentTypeRoles::TRASH])) {
                 $trashLink = $menuEntry->addChild('sidebar_menu.content_type.trash', 'fa fa-trash', Routes::DATA_TRASH, ['contentType' => $contentType->getId()]);
                 $trashLink->setTranslation([]);
             }

--- a/src/Service/ContentTypeService.php
+++ b/src/Service/ContentTypeService.php
@@ -545,9 +545,8 @@ class ContentTypeService implements EntityServiceInterface
             $this->addMenuViewLinks($contentType, $menuEntry);
             $this->addDraftInProgressLink($contentType, $menuEntry);
 
-            $showCreate = $this->authorizationChecker->isGranted($roles[ContentTypeRoles::SHOW_LINK_CREATE]);
-
-            if ($showCreate && $this->authorizationChecker->isGranted($contentType->getCreateRole())) {
+            if ($this->authorizationChecker->isGranted($roles[ContentTypeRoles::SHOW_LINK_CREATE])
+                && $this->authorizationChecker->isGranted($roles[ContentTypeRoles::CREATE])) {
                 $createLink = $menuEntry->addChild('sidebar_menu.content_type.create', 'fa fa-plus', Routes::DATA_ADD, ['contentType' => $contentType->getId()]);
                 $createLink->setTranslation([
                     '%name%' => $contentType->getSingularName(),

--- a/src/Service/ContentTypeService.php
+++ b/src/Service/ContentTypeService.php
@@ -600,7 +600,7 @@ class ContentTypeService implements EntityServiceInterface
 
     private function addDraftInProgressLink(ContentType $contentType, MenuEntry $menuEntry): void
     {
-        if (!$contentType->giveEnvironment()->getManaged() || !$menuEntry->hasBadge() || !$this->authorizationChecker->isGranted($contentType->getEditRole())) {
+        if (!$contentType->giveEnvironment()->getManaged() || !$menuEntry->hasBadge() || !$this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::EDIT))) {
             return;
         }
 

--- a/src/Service/ContentTypeService.php
+++ b/src/Service/ContentTypeService.php
@@ -531,8 +531,10 @@ class ContentTypeService implements EntityServiceInterface
 
         foreach ($this->orderedContentTypes as $contentType) {
             $roles = $contentType->getRoles();
-            $role = $contentType->getViewRole();
-            if ($contentType->getDeleted() || !$contentType->getActive() || (null !== $role && !$this->authorizationChecker->isGranted($role)) && !$contentType->getRootContentType()) {
+
+            if ($contentType->getDeleted()
+                || !$contentType->getActive()
+                || (!$this->authorizationChecker->isGranted($roles[ContentTypeRoles::VIEW])) && !$contentType->getRootContentType()) {
                 continue;
             }
             $menuEntry = new MenuEntry($contentType->getPluralName(), $contentType->getIcon() ?? 'fa fa-book', Routes::DATA_DEFAULT_VIEW, ['type' => $contentType->getName()], $contentType->getColor());

--- a/src/Service/ContentTypeService.php
+++ b/src/Service/ContentTypeService.php
@@ -9,6 +9,7 @@ use EMS\CommonBundle\Entity\EntityInterface;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\UI\Menu;
 use EMS\CoreBundle\Core\UI\MenuEntry;
 use EMS\CoreBundle\Entity\ContentType;
@@ -529,6 +530,7 @@ class ContentTypeService implements EntityServiceInterface
         $circleContentType = $this->getCircleContentType();
 
         foreach ($this->orderedContentTypes as $contentType) {
+            $roles = $contentType->getRoles();
             $role = $contentType->getViewRole();
             if ($contentType->getDeleted() || !$contentType->getActive() || (null !== $role && !$this->authorizationChecker->isGranted($role)) && !$contentType->getRootContentType()) {
                 continue;
@@ -540,7 +542,10 @@ class ContentTypeService implements EntityServiceInterface
             $this->addMenuSearchLinks($contentType, $menuEntry, $circleContentType, $user);
             $this->addMenuViewLinks($contentType, $menuEntry);
             $this->addDraftInProgressLink($contentType, $menuEntry);
-            if ($this->authorizationChecker->isGranted($contentType->getCreateRole())) {
+
+            $showCreate = $this->authorizationChecker->isGranted($roles[ContentTypeRoles::SHOW_LINK_CREATE]);
+
+            if ($showCreate && $this->authorizationChecker->isGranted($contentType->getCreateRole())) {
                 $createLink = $menuEntry->addChild('sidebar_menu.content_type.create', 'fa fa-plus', Routes::DATA_ADD, ['contentType' => $contentType->getId()]);
                 $createLink->setTranslation([
                     '%name%' => $contentType->getSingularName(),
@@ -560,7 +565,9 @@ class ContentTypeService implements EntityServiceInterface
 
     private function addMenuSearchLinks(ContentType $contentType, MenuEntry $menuEntry, ?ContentType $circleContentType, UserInterface $user): void
     {
-        if (!$this->authorizationChecker->isGranted($contentType->getSearchLinkDisplayRole())) {
+        $roles = $contentType->getRoles();
+
+        if (!$this->authorizationChecker->isGranted($roles[ContentTypeRoles::SHOW_LINK_SEARCH])) {
             return;
         }
 

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -203,7 +203,7 @@ class DataService
      */
     public function lockRevision(Revision $revision, Environment $publishEnv = null, bool $super = false, ?string $username = null): string
     {
-        if (!empty($publishEnv) && !$this->authorizationChecker->isGranted($revision->giveContentType()->getPublishRole() ?: 'ROLE_PUBLISHER')) {
+        if (!empty($publishEnv) && !$this->authorizationChecker->isGranted($revision->giveContentType()->role(ContentTypeRoles::PUBLISH))) {
             throw new PrivilegeException($revision, 'You don\'t have publisher role for this content');
         }
         if (!empty($publishEnv) && \is_object($publishEnv) && !empty($publishEnv->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && !$this->appTwig->inMyCircles($publishEnv->getCircles())) {

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -1078,7 +1078,7 @@ class DataService
         $revision->setLockUntil(new \DateTime($this->lockTime));
 
         if (null !== $currentUser
-            && $this->userService->isGrantedRole((string) $contentType->getRoles()[ContentTypeRoles::OWNER])) {
+            && $this->userService->isGrantedRole($contentType->role(ContentTypeRoles::OWNER))) {
             $revision->setOwner($currentUser->getUsername());
         }
 

--- a/src/Service/DataService.php
+++ b/src/Service/DataService.php
@@ -14,6 +14,7 @@ use EMS\CommonBundle\Helper\ArrayTool;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CommonBundle\Storage\StorageManager;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\DataField;
@@ -1076,8 +1077,8 @@ class DataService
         $revision->setLockBy($username);
         $revision->setLockUntil(new \DateTime($this->lockTime));
 
-        $ownerRole = $contentType->getOwnerRole();
-        if (null !== $currentUser && null !== $ownerRole && $this->userService->isGrantedRole($ownerRole)) {
+        if (null !== $currentUser
+            && $this->userService->isGrantedRole((string) $contentType->getRoles()[ContentTypeRoles::OWNER])) {
             $revision->setOwner($currentUser->getUsername());
         }
 

--- a/src/Service/PublishService.php
+++ b/src/Service/PublishService.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\NonUniqueResultException;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\Elasticsearch\Bulker;
 use EMS\CoreBundle\Entity\ContentType;
@@ -275,7 +276,7 @@ class PublishService
                 return;
             }
 
-            if (!$this->authorizationChecker->isGranted($revision->giveContentType()->getPublishRole())) {
+            if (!$this->authorizationChecker->isGranted($revision->giveContentType()->role(ContentTypeRoles::PUBLISH))) {
                 $this->logger->warning('service.publish.not_authorized', [
                     EmsFields::LOG_CONTENTTYPE_FIELD => $revision->giveContentType()->getName(),
                     EmsFields::LOG_OUUID_FIELD => $revision->giveOuuid(),
@@ -328,7 +329,7 @@ class PublishService
             return false;
         }
 
-        if (!$this->authorizationChecker->isGranted($revision->giveContentType()->getPublishRole())) {
+        if (!$this->authorizationChecker->isGranted($revision->giveContentType()->role(ContentTypeRoles::PUBLISH))) {
             $this->logger->warning('service.publish.not_authorized', $logContext);
 
             return false;
@@ -355,7 +356,7 @@ class PublishService
             return;
         }
 
-        if (!$this->authorizationChecker->isGranted($contentType->getPublishRole())) {
+        if (!$this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::PUBLISH))) {
             $this->logger->warning('service.publish.not_authorized', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),
                 EmsFields::LOG_OUUID_FIELD => $ouuid,

--- a/src/Service/ReleaseRevisionService.php
+++ b/src/Service/ReleaseRevisionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Service;
 
 use EMS\CommonBundle\Entity\EntityInterface;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Release;
 use EMS\CoreBundle\Entity\ReleaseRevision;
@@ -138,7 +139,7 @@ final class ReleaseRevisionService implements QueryServiceInterface, EntityServi
     {
         $contentTypes = [];
         foreach ($this->contentTypeService->getAll() as $contentType) {
-            if (!$contentType->getDeleted() && null !== $contentType->getPublishRole() && $this->userService->isGrantedRole($contentType->getPublishRole())) {
+            if (!$contentType->getDeleted() && $this->userService->isGrantedRole($contentType->role(ContentTypeRoles::PUBLISH))) {
                 $contentTypes[] = $contentType->getName();
             }
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Added a new roles json to the contentType entity. 
The roles array has as key the permission and as value the selected role.

Important, the roles object allways build all permissions. Isset check are not needed.

If you want to disable for all users -> select not defined
If you want to enable for all user -> select ROLE_USER
