### PR TITLE
fix(revision-view): custom data link view no results > returns all

### DIFF
--- a/src/Controller/Search/QuerySearchController.php
+++ b/src/Controller/Search/QuerySearchController.php
@@ -31,6 +31,10 @@ final class QuerySearchController extends AbstractController
     {
         $dataLinks = $this->dataLinksFactory->create($request);
 
+        if ($dataLinks->hasCustomViewRendered()) {
+            return new JsonResponse($dataLinks->toArray());
+        }
+
         if ($dataLinks->isQuerySearch()) {
             $this->querySearchService->querySearchDataLinks($dataLinks);
         } elseif (!$dataLinks->hasItems()) {

--- a/src/Core/Document/DataLinks.php
+++ b/src/Core/Document/DataLinks.php
@@ -25,6 +25,8 @@ final class DataLinks
     private ?int $searchId = null;
     private int $total = 0;
 
+    private bool $customViewRendered = false;
+
     public function __construct(int $page, string $pattern)
     {
         $this->page = $page;
@@ -89,6 +91,11 @@ final class DataLinks
         }
     }
 
+    public function customViewRendered(): void
+    {
+        $this->customViewRendered = true;
+    }
+
     /**
      * @return string[]
      */
@@ -146,6 +153,11 @@ final class DataLinks
     public function getSize(): int
     {
         return self::SIZE;
+    }
+
+    public function hasCustomViewRendered(): bool
+    {
+        return $this->customViewRendered;
     }
 
     public function hasItems(): bool

--- a/src/Core/Document/DataLinksFactory.php
+++ b/src/Core/Document/DataLinksFactory.php
@@ -75,5 +75,6 @@ final class DataLinksFactory
         /** @var DataLinkViewType $viewType */
         $viewType = $this->viewTypes->get('ems.view.data_link');
         $viewType->render($customView, $dataLinks);
+        $dataLinks->customViewRendered();
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

If the custom data link view, does not add any items the result should be empty.