### PR TITLE
fix(environment): recompute command broken

### DIFF
--- a/src/Core/User/UserManager.php
+++ b/src/Core/User/UserManager.php
@@ -50,6 +50,15 @@ final class UserManager
         return $user;
     }
 
+    public function getUser(): ?User
+    {
+        try {
+            return $this->getAuthenticatedUser();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
     public function getAuthenticatedUser(): User
     {
         $token = $this->getToken();

--- a/src/Form/Form/RevisionType.php
+++ b/src/Form/Form/RevisionType.php
@@ -39,8 +39,8 @@ class RevisionType extends AbstractType
     {
         /** @var Revision|null $revision */
         $revision = $builder->getData();
-        $user = $this->userManager->getAuthenticatedUser();
-        $simplifiedUI = $user->getUserOptions()->isEnabled(UserOptions::SIMPLIFIED_UI);
+        $user = $this->userManager->getUser();
+        $simplifiedUI = $user && $user->getUserOptions()->isEnabled(UserOptions::SIMPLIFIED_UI);
         $contentType = $revision ? $revision->giveContentType() : $options['content_type'];
 
         if (!$contentType instanceof ContentType) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Bug introduced in #1224

In UserManager.php line 197:
Token is null, could not get the currentUser from token.

Offcourse CLI, there is no authenticated user