### PR TITLE
fix(route): change upload file api endpoint

### DIFF
--- a/src/Resources/config/routing/api/file.xml
+++ b/src/Resources/config/routing/api/file.xml
@@ -34,7 +34,7 @@
         <default key="apiRoute"><bool>true</bool></default>
         <default key="sha1" xsi:nil="true"/>
     </route>
-    <route id="ems_api_image_upload_url" path="/" methods="POST">
+    <route id="ems_api_image_upload_url" path="/upload" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\ContentManagement\FileController::uploadFileAction</default>
         <default key="_format">json</default>
     </route>


### PR DESCRIPTION
The "march" refactoring broke the endpoint by adding a slash at the end. We fix that here and add more consistency. A related PR in the client-helper : https://github.com/ems-project/EMSClientHelperBundle/pull/365

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	
