### PR TITLE
fix(views/search): not specify the value (0) of the env, use first

### DIFF
--- a/src/Resources/views/elasticsearch/search.html.twig
+++ b/src/Resources/views/elasticsearch/search.html.twig
@@ -243,7 +243,7 @@
 			</div>
 		</div>
 	</div>
-		{% if body is defined and form.environments.vars.value|length == 1  and form.contentTypes.vars.value|length == 1  and is_granted(form.contentTypes.vars.value.0|get_content_type.roles.publish) and form.environments.vars.value.0|get_environment.managed and response.total > 1 %}
+		{% if body is defined and form.environments.vars.value|length == 1  and form.contentTypes.vars.value|length == 1  and is_granted(form.contentTypes.vars.value.0|get_content_type.roles.publish) and form.environments.vars.value|first|get_environment.managed and response.total > 1 %}
 			<div class="col-md-12">
 				<div class="box">
 					<div class="box-footer with-border">


### PR DESCRIPTION
Rarely the default environment for a CT is not the first in the environments order (0)

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

![2022-11-04_11h08_13](https://user-images.githubusercontent.com/832641/199947469-28eef7bb-f083-45b0-8f8e-a725ec9a17a8.png)


